### PR TITLE
Add CircuitResult class

### DIFF
--- a/qiskit_experiments/framework/__init__.py
+++ b/qiskit_experiments/framework/__init__.py
@@ -203,6 +203,7 @@ Experiment Data Classes
     :toctree: ../stubs/
 
     ExperimentData
+    CircuitData
     ExperimentStatus
     JobStatus
     AnalysisStatus
@@ -247,7 +248,7 @@ from .base_analysis import BaseAnalysis
 from .base_experiment import BaseExperiment
 from .configs import ExperimentConfig, AnalysisConfig
 from .analysis_result_data import AnalysisResultData
-from .experiment_data import ExperimentData
+from .experiment_data import ExperimentData, CircuitData
 from .composite import (
     ParallelExperiment,
     BatchExperiment,


### PR DESCRIPTION
This is kind of QiskitExperiment version of ExperimentResult class in terra. This ensures we have run options in the metadata and thus bootstrap data processor and marginalization protocol.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR adds `CircuitResult` class which is the replacement of free form dictionary currently we use as a container of experiment data from the single circuit execution. This data guarantees we have required run options with it, thus we can bootstrap data processing.

### Details and comments


