### PR TITLE
calibrations.save() preserve working directory when fails

### DIFF
--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -1407,7 +1407,6 @@ class Calibrations:
         else:
             raise CalibrationError(f"Saving to .{file_type} is not yet supported.")
 
-
     def schedule_information(self) -> Tuple[List[str], List[Dict]]:
         """Get the information on the schedules stored in the calibrations.
 

--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -1315,7 +1315,7 @@ class Calibrations:
     def save(
         self,
         file_type: str = "csv",
-        folder: str = None,
+        folder: str = "",
         overwrite: bool = False,
         file_prefix: str = "",
         most_recent_only: bool = False,
@@ -1350,13 +1350,9 @@ class Calibrations:
         """
         warnings.warn("Schedules are only saved in text format. They cannot be re-loaded.")
 
-        cwd = os.getcwd()
-        if folder:
-            os.chdir(folder)
-
-        parameter_config_file = file_prefix + "parameter_config.csv"
-        parameter_value_file = file_prefix + "parameter_values.csv"
-        schedule_file = file_prefix + "schedules.csv"
+        parameter_config_file = os.path.join(folder, file_prefix + "parameter_config.csv")
+        parameter_value_file = os.path.join(folder, file_prefix + "parameter_values.csv")
+        schedule_file = os.path.join(folder, file_prefix + "schedules.csv")
 
         if os.path.isfile(parameter_config_file) and not overwrite:
             raise CalibrationError(
@@ -1411,7 +1407,6 @@ class Calibrations:
         else:
             raise CalibrationError(f"Saving to .{file_type} is not yet supported.")
 
-        os.chdir(cwd)
 
     def schedule_information(self) -> Tuple[List[str], List[Dict]]:
         """Get the information on the schedules stored in the calibrations.


### PR DESCRIPTION
### Summary
fix bug #621 .
calibrations.save() will no longer change the working directory while saving the data, and therefore will preserve it even if it fails to save the data.

### Details and comments
also changed the default of folder to an empty string instead of a None (because the default is actually the current directory)

