### PR TITLE
Cleaner specification for RB experiments

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
@@ -110,17 +110,6 @@ def _circuit_compose(
     return self
 
 
-def _truncate_inactive_qubits(
-    circ: QuantumCircuit, active_qubits: Sequence[Qubit]
-) -> QuantumCircuit:
-    res = QuantumCircuit(active_qubits, name=circ.name, metadata=circ.metadata)
-    for inst in circ:
-        if all(q in active_qubits for q in inst.qubits):
-            res.append(inst)
-    res.calibrations = circ.calibrations
-    return res
-
-
 def _synthesize_clifford_circuit(
     circuit: QuantumCircuit, basis_gates: Tuple[str]
 ) -> QuantumCircuit:

--- a/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
@@ -115,7 +115,12 @@ def _synthesize_clifford_circuit(
 ) -> QuantumCircuit:
     # synthesizes clifford circuits using given basis gates, for use during
     # custom transpilation during RB circuit generation.
-    return transpile(circuit, basis_gates=list(basis_gates), optimization_level=1)
+    return transpile(
+        circuit,
+        basis_gates=list(basis_gates),
+        coupling_map=[[0, 1]] if circuit.num_qubits == 2 else None,
+        optimization_level=1,
+    )
 
 
 @lru_cache(maxsize=None)
@@ -549,6 +554,7 @@ _CLIFFORD_LAYER = (
     _create_cliff_2q_layer_1(),
     _create_cliff_2q_layer_2(),
 )
+# _NUM_LAYER_0 = 36
 _NUM_LAYER_1 = 20
 _NUM_LAYER_2 = 16
 

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -12,6 +12,7 @@
 """
 Interleaved RB Experiment class.
 """
+import copy
 import itertools
 import warnings
 from typing import Union, Iterable, Optional, List, Sequence, Tuple
@@ -20,14 +21,11 @@ from numpy.random import Generator
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 
 from qiskit.circuit import QuantumCircuit, Instruction, Gate, Delay
-from qiskit.compiler import transpile
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
 from qiskit.quantum_info import Clifford
-from qiskit.transpiler.exceptions import TranspilerError
 from qiskit_experiments.framework import Options
 from qiskit_experiments.framework.backend_timing import BackendTiming
-from .clifford_utils import _truncate_inactive_qubits
 from .clifford_utils import num_from_1q_circuit, num_from_2q_circuit
 from .interleaved_rb_analysis import InterleavedRBAnalysis
 from .standard_rb import StandardRB, SequenceElementType
@@ -59,7 +57,7 @@ class InterleavedRB(StandardRB):
 
     def __init__(
         self,
-        interleaved_element: Union[QuantumCircuit, Gate, Delay, Clifford],
+        interleaved_element: Union[QuantumCircuit, Gate, Delay],
         physical_qubits: Sequence[int],
         lengths: Iterable[int],
         backend: Optional[Backend] = None,
@@ -71,10 +69,9 @@ class InterleavedRB(StandardRB):
         """Initialize an interleaved randomized benchmarking experiment.
 
         Args:
-            interleaved_element: The element to interleave,
-                    given either as a Clifford element, gate, delay or circuit.
-                    If the element contains any non-basis gates,
-                    it will be transpiled with ``transpiled_options`` of this experiment.
+            interleaved_element: The Clifford element to interleave,
+                    given either as a gate, delay or circuit.
+                    It must consists only of basis gates if a backend is supplied.
                     If it is/contains a delay, its duration and unit must comply with
                     the timing constraints of the ``backend``
                     (:class:`~qiskit_experiments.framework.backend_timing.BackendTiming`
@@ -186,8 +183,7 @@ class InterleavedRB(StandardRB):
             A list of :class:`QuantumCircuit`.
 
         Raises:
-            QiskitError: If the ``interleaved_element`` provided to the constructor
-                cannot be transpiled.
+            QiskitError: If ``interleaved_element`` contains any gate not in backend's basis gates.
         """
         # Convert interleaved element to transpiled circuit operation and store it for speed
         self.__set_up_interleaved_op()
@@ -233,37 +229,16 @@ class InterleavedRB(StandardRB):
         return super()._to_instruction(elem, basis_gates)
 
     def __set_up_interleaved_op(self) -> None:
-        # Convert interleaved element to transpiled circuit operation and store it for speed
-        self._interleaved_op = self._interleaved_element
+        self._interleaved_op = copy.deepcopy(self._interleaved_element)
+        # Validate if interleaved element consists only of basis gates
         basis_gates = self._get_basis_gates()
-        # Convert interleaved element to circuit
-        if isinstance(self._interleaved_op, Clifford):
-            self._interleaved_op = self._interleaved_op.to_circuit()
-
-        if isinstance(self._interleaved_op, QuantumCircuit):
-            interleaved_circ = self._interleaved_op
-        elif isinstance(self._interleaved_op, Gate):
-            interleaved_circ = QuantumCircuit(self.num_qubits, name=self._interleaved_op.name)
-            interleaved_circ.append(self._interleaved_op, list(range(self.num_qubits)))
-        else:  # Delay
-            interleaved_circ = []
-
-        if basis_gates and any(i.operation.name not in basis_gates for i in interleaved_circ):
-            # Transpile circuit with non-basis gates and remove idling qubits
-            try:
-                interleaved_circ = transpile(
-                    interleaved_circ, self.backend, **vars(self.transpile_options)
-                )
-            except TranspilerError as err:
-                raise QiskitError("Failed to transpile interleaved_element.") from err
-            interleaved_circ = _truncate_inactive_qubits(
-                interleaved_circ, active_qubits=interleaved_circ.qubits[: self.num_qubits]
-            )
-            # Convert transpiled circuit to operation
-            if len(interleaved_circ) == 1:
-                self._interleaved_op = interleaved_circ.data[0].operation
-            else:
-                self._interleaved_op = interleaved_circ
+        if basis_gates:
+            ops = [self._interleaved_op]
+            if isinstance(self._interleaved_op, QuantumCircuit):
+                ops = [i.operation for i in self._interleaved_op]
+            for op in ops:
+                if op.name not in basis_gates:
+                    raise QiskitError(f"interleaved_element contains a non-basis gate: {op.name}")
 
         # Store interleaved operation as Instruction
         if isinstance(self._interleaved_op, QuantumCircuit):

--- a/test/library/randomized_benchmarking/test_interleaved_rb.py
+++ b/test/library/randomized_benchmarking/test_interleaved_rb.py
@@ -286,6 +286,28 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
                 if inst.operation.name == "cx":
                     self.assertEqual(inst.qubits, expected_qubits)
 
+    def test_interleaved_element_contains_non_basis_gates(self):
+        """Raise if interleaved_element contains any non basis gate"""
+        with self.assertRaises(QiskitError):
+            rb.InterleavedRB(
+                interleaved_element=CZGate(),  # CZ gate is not in Manila's basis gates
+                physical_qubits=[0, 1],
+                lengths=[1, 2, 3],
+                backend=self.backend,
+            ).circuits()
+
+        qc_cnot = QuantumCircuit(2)
+        qc_cnot.h(1)
+        qc_cnot.cz(0, 1)
+        qc_cnot.h(1)
+        with self.assertRaises(QiskitError):
+            rb.InterleavedRB(
+                interleaved_element=qc_cnot,  # Equivalent with CNOT but it contains CZ (non basis)
+                physical_qubits=[0, 1],
+                lengths=[1, 2, 3],
+                backend=self.backend,
+            ).circuits()
+
 
 class TestRunInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
     """Test for running InterleavedRB."""

--- a/test/library/randomized_benchmarking/test_interleaved_rb.py
+++ b/test/library/randomized_benchmarking/test_interleaved_rb.py
@@ -266,15 +266,15 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
             self.assertTrue(all(not inst.operation.name.startswith("Clifford") for inst in qc))
 
     def test_interleaving_cnot_gate_with_non_supported_direction(self):
-        """Test if cx(0, 1) can be interleaved for backend that support only cx(1, 0)."""
+        """Test if, for backend that support only cx(1, 0), cx(1, 0) can be interleaved
+        but cx(0, 1) cannot."""
         my_backend = FakeManilaV2()
         del my_backend.target["cx"][(0, 1)]  # make support only cx(1, 0)
 
         exp = rb.InterleavedRB(
             interleaved_element=CXGate(),
-            physical_qubits=(0, 1),
+            physical_qubits=(1, 0),  # supported
             lengths=[3],
-            num_samples=4,
             backend=my_backend,
             seed=1234,
         )
@@ -285,6 +285,47 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
             for inst in qc:
                 if inst.operation.name == "cx":
                     self.assertEqual(inst.qubits, expected_qubits)
+
+        exp = rb.InterleavedRB(
+            interleaved_element=CXGate(),
+            physical_qubits=(0, 1),  # not supported
+            lengths=[3],
+            backend=my_backend,
+        )
+        with self.assertRaises(QiskitError):
+            exp._transpiled_circuits()
+
+    def test_interleaving_circuit_with_gates_with_non_supported_direction(self):
+        """Test if, for backend that support only cx(2, 1),
+        circuit only with cx(2, 1) can be interleaved but circuit with cx(1, 2) cannot."""
+        my_backend = FakeManilaV2()
+        del my_backend.target["cx"][(1, 2)]  # make support only cx(2, 1)
+
+        circ = QuantumCircuit(2)
+        circ.sx(0)
+        circ.cx(0, 1)
+        exp = rb.InterleavedRB(
+            interleaved_element=circ,
+            physical_qubits=(2, 1),  # supported
+            lengths=[3],
+            backend=my_backend,
+        )
+        transpiled = exp._transpiled_circuits()
+        for qc in transpiled:
+            self.assertTrue(qc.count_ops().get("cx", 0) > 0)
+            expected_qubits = (qc.qubits[2], qc.qubits[1])
+            for inst in qc:
+                if inst.operation.name == "cx":
+                    self.assertEqual(inst.qubits, expected_qubits)
+
+        exp = rb.InterleavedRB(
+            interleaved_element=circ,
+            physical_qubits=(1, 2),  # not supported
+            lengths=[3],
+            backend=my_backend,
+        )
+        with self.assertRaises(QiskitError):
+            exp._transpiled_circuits()
 
     def test_interleaved_element_contains_non_basis_gates(self):
         """Raise if interleaved_element contains any non basis gate"""

--- a/test/library/randomized_benchmarking/test_standard_rb.py
+++ b/test/library/randomized_benchmarking/test_standard_rb.py
@@ -191,9 +191,9 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
     def test_backend_with_directed_basis_gates(self):
         """Test if correct circuits are generated from backend with directed basis gates."""
         my_backend = copy.deepcopy(self.backend)
-        del my_backend.target["cx"][(1, 2)]  # make cx on {1, 2} one-sided
+        del my_backend.target["cx"][(1, 2)]  # make support only cx(2, 1)
 
-        exp = rb.StandardRB(physical_qubits=(1, 2), lengths=[3], num_samples=4, backend=my_backend)
+        exp = rb.StandardRB(physical_qubits=(2, 1), lengths=[3], num_samples=4, backend=my_backend)
         transpiled = exp._transpiled_circuits()
         for qc in transpiled:
             self.assertTrue(qc.count_ops().get("cx", 0) > 0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

This commit introduces the following API breaking changes that make the specification of StandardRB and InterleavedRB simpler and clearer.
- Make 2Q RB physical qubits direction aware
    This change allows users to be able to benchmark one direction of 2q-gate, e.g. cx(2, 1), by StandardRB. That means the RB circuits contains only cx(2, 1) if `qubits=(2, 1)` is supplied. Previously, if the backend supports both cx(1, 2) and cx(2, 1), the circuits may contains both of them, and the mix of them were benchmarked. 
    - Pros: Faster circuit generation even for backends with non-bidirectional coupling graph by avoiding transpilation of full circuits, e.g. IBM Quantum processors with ECRGates.
    - Cons: Nothing as long users can define custom Clifford pulse gates easily. -> #1032 Interleaved 2q-gate have to be always defined in the direction of basis 2q-gate of the device. If the device support only cx(2, 1) and if you want to interleave a custom cx(1, 2) pulse gate, you need to define a custom gate with inverted cx (control and target are swapped) as its definition and add its calibration (pulse schedule) onto qubits (2, 1). 
- Change `InterleavedRB` to accept only basis gates for `interleaved_element`
    This change requires users to decompose `interleaved_element` before constructing an `InterleavedRB` experiment. This should not be demanding because they must know what gate (or sequence of gates) are actually interleaved and characterized.
    - Pros: Users can clearly see what they have interleaved, Simpler code.
    - Cons: Nothing as long users can define custom Clifford pulse gates easily. -> #1032 
