### PR TITLE
Minimal working code examples for experiments API docs

### DIFF
--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -33,6 +33,28 @@ class T1(BaseExperiment):
         wait time is fitted to an exponential curve to obtain an estimate for
         :math:`T_1`.
 
+    # section: example
+
+        Here's a minimal working example:
+
+        .. jupyter-execute::
+            :hide-code:
+
+            from qiskit_experiments.test.noisy_delay_aer_simulator import NoisyDelayAerBackend
+
+            t1 = 25e-6
+            backend = NoisyDelayAerBackend([t1], [t1 / 2])
+
+        .. jupyter-execute::
+
+            from qiskit_experiments.library import T1
+
+            exp = T1(physical_qubits = (0,),
+                     delays = [1e-6, 5e-6, 10e-6])
+
+            exp_data = exp.run(backend).block_for_results()
+            exp_data.figure(0)
+
     # section: analysis_ref
         :class:`.T1Analysis`
 
@@ -66,6 +88,11 @@ class T1(BaseExperiment):
                 estimated.
             delays: Delay times of the experiments in seconds.
             backend: Optional, the backend to run the experiment on.
+
+        Default Arg Vals:
+            physical_qubits = 0
+            delays = np.arange(1e-6, 40e-6, 3e-6)
+            backend = NoisyDelayAerBackend([25e-6], [25e-6 / 2])
 
         Raises:
             ValueError: If the number of delays is smaller than 3

--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -48,12 +48,19 @@ class T1(BaseExperiment):
         .. jupyter-execute::
 
             from qiskit_experiments.library import T1
+            import numpy as np
 
             exp = T1(physical_qubits = (0,),
-                     delays = [1e-6, 5e-6, 10e-6])
+                     delays = np.arange(1e-6, 30e-5, 3e-5))
 
             exp_data = exp.run(backend).block_for_results()
             exp_data.figure(0)
+
+        The experiment executes a series of circuits with this form:
+
+        .. jupyter-execute::
+
+            exp.circuits()[0].draw("mpl")
 
     # section: analysis_ref
         :class:`.T1Analysis`

--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -89,11 +89,6 @@ class T1(BaseExperiment):
             delays: Delay times of the experiments in seconds.
             backend: Optional, the backend to run the experiment on.
 
-        Default Arg Vals:
-            physical_qubits = 0
-            delays = np.arange(1e-6, 40e-6, 3e-6)
-            backend = NoisyDelayAerBackend([25e-6], [25e-6 / 2])
-
         Raises:
             ValueError: If the number of delays is smaller than 3
         """

--- a/qiskit_experiments/library/characterization/t2hahn.py
+++ b/qiskit_experiments/library/characterization/t2hahn.py
@@ -53,6 +53,36 @@ class T2Hahn(BaseExperiment):
         the delay in the metadata is the total delay which is delay * (num_echoes +1)
         The circuits are run on the device or on a simulator backend.
 
+    # section: example
+
+        Here's a minimal working example:
+
+        .. jupyter-execute::
+            :hide-code:
+
+            from qiskit_experiments.test.t2hahn_backend import T2HahnBackend
+
+            osc_freq = 0.1
+            estimated_t2hahn = 20
+
+            backend = T2HahnBackend(
+                            t2hahn=[estimated_t2hahn],
+                            frequency=[osc_freq],
+                            initialization_error=[0.0],
+                            readout0to1=[0.02],
+                            readout1to0=[0.02],
+                       )
+
+        .. jupyter-execute::
+
+            from qiskit_experiments.library import T2Hahn
+
+            exp = T2Hahn(physical_qubits = (0,),
+                         delays = [1e-6, 5e-6, 10e-6])
+
+            exp_data = exp.run(backend).block_for_results()
+            exp_data.figure(0)
+
     # section: manual
         :doc:`/manuals/characterization/t2hahn`
 
@@ -85,7 +115,7 @@ class T2Hahn(BaseExperiment):
         backend: Optional[Backend] = None,
     ):
         """
-        Initialize the T2 - Hahn Echo class
+        Initialize the T2 Hahn Echo class.
 
         Args:
             physical_qubits: a single-element sequence containing the qubit whose T2 is to be

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -38,20 +38,35 @@ class T2Ramsey(BaseExperiment):
         :math:`T_2`, which is measured by :class:`.T2Hahn`, :math:`T_2^*` is sensitive
         to inhomogenous broadening.
 
-        This experiment consists of a series of circuits of the form
+    # section: example
 
-        .. parsed-literal::
+        Here's a minimal working code example:
 
-                 ┌───┐┌──────────────┐┌──────┐ ░ ┌───┐ ░ ┌─┐
-            q_0: ┤ H ├┤   DELAY(t)   ├┤ P(λ) ├─░─┤ H ├─░─┤M├
-                 └───┘└──────────────┘└──────┘ ░ └───┘ ░ └╥┘
-            c: 1/═════════════════════════════════════════╩═
-                                                        0
+        .. jupyter-execute::
+            :hide-code:
 
-        for each *t* from the specified delay times, where
-        :math:`\lambda =2 \pi \times {osc\_freq}`,
-        and the delays are specified by the user.
-        The circuits are run on the device or on a simulator backend.
+            from qiskit_experiments.test.noisy_delay_aer_simulator import NoisyDelayAerBackend
+
+            t2 = 100e-6
+            backend = NoisyDelayAerBackend([t2 * 2], [t2])
+
+        .. jupyter-execute::
+
+            from qiskit_experiments.library import T2Ramsey
+            import numpy as np
+
+            exp = T2Ramsey(physical_qubits = (0,),
+                     delays = np.arange(1e-6, 50e-6, 2e-6),
+                     osc_freq = 1e5)
+            exp_data = exp.run(backend).block_for_results()
+            exp_data.figure(0)
+
+        The experiment executes a series of circuits with this form:
+
+        .. jupyter-execute::
+
+            exp.circuits()[0].draw("mpl")
+
 
     # section: manual
         :doc:`/manuals/characterization/t2ramsey`


### PR DESCRIPTION
### Summary

As a response to user feedback that it would be useful to have a code snippet to copy for each experiment, this PR adds minimal working examples to the API pages for each experiment. This uses the Example section which already exists and hides the test backend setup in a `:hide-code:` block. Since the code block is meant to work when copied directly, it should have all the imports needed for the experiment itself (except for the backend, which we assume the user will provide).