### PR TITLE
Use tox plugin to consolidate tox environments

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -67,7 +67,7 @@ jobs:
           python -m pip install -U tox
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
-        run: tox -edocs-qiskit-main
+        run: tox -eqiskit-main --alt docs
       - name: Compress Artifacts
         run: |
           mkdir artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Deps
         run: python -m pip install -U tox
       - name: Run lint
-        run: tox -elint
+        run: tox -epy --alt lint
   docs:
     if: github.repository_owner == 'Qiskit-Extensions'
     name: docs
@@ -102,7 +102,7 @@ jobs:
           python -m pip install -U tox
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
-        run: tox -edocs-parallel
+        run: tox -edocs --alt parallel
       - name: Compress Artifacts
         run: |
           mkdir artifacts

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ pylatexenc
 multimethod
 sphinx-copybutton
 coverage>=5.5
+tox  # for pylint to check toxfile.py
 # Pin versions below because of build errors
 ipykernel<=6.21.3
 jupyter-client<=8.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ envlist = py311,py310,py39,py38,lint
 isolated_build = true
 
 [testenv]
+runner = alternative_commands
 usedevelop = True
 install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
 setenv =
-  VIRTUAL_ENV={envdir}
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
   QISKIT_TEST_CAPTURE_STREAMS=1
   OMP_NUM_THREADS={env:OMP_NUM_THREADS:1}
@@ -20,97 +20,61 @@ passenv =
   QISKIT_IBM_*
   TEST_TIMEOUT
   QE_USE_TESTTOOLS
+  # The following variables are for docs builds but should not affect regular tests
+  EXPERIMENTS_DEV_DOCS
+  PROD_BUILD
+  RELEASE_STRING
+  VERSION_STRING
+allowlist_externals =
+  git
 commands = stestr run {posargs}
-
-[testenv:cover]
-basepython = python3
-setenv =
-    {[testenv]setenv}
-    PYTHON=coverage3 run --source qiskit_experiments --parallel-mode
-commands =
+alternative_commands =
+  cover =
+    add_setenv PYTHON=coverage3 run --source qiskit_experiments --parallel-mode
     stestr run {posargs}
     coverage3 combine
     coverage3 lcov
+  lint =
+    black --check qiskit_experiments test tools setup.py toxfile.py
+    pylint -rn {posargs} --rcfile={toxinidir}/.pylintrc qiskit_experiments/ test/ tools/ toxfile.py
+    python {toxinidir}/tools/verify_headers.py
+  lint-incr =
+    black --check {posargs} qiskit_experiments test tools setup.py toxfile.py
+    -git fetch -q https://github.com/Qiskit-Extensions/qiskit-experiments :lint_incr_latest
+    python {toxinidir}/tools/pylint_incr.py -rn {posargs} -sn --paths :/qiskit_experiments/*.py :/test/*.py :/tools/*.py :/toxfile.py
+    python {toxinidir}/tools/verify_headers.py qiskit_experiments test tools
+  black =
+    black {posargs} qiskit_experiments test tools setup.py toxfile.py
 
 [testenv:qiskit-main]
-usedevelop = True
+runner = alternative_commands
 install_command = pip install -U {opts} {packages}
 deps =
   git+https://github.com/Qiskit/qiskit
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/requirements-extras.txt
 commands = stestr run {posargs}
-
-
-[testenv:lint]
-envdir = .tox/lint
-commands =
-  black --check qiskit_experiments test tools setup.py
-  pylint -rn {posargs} --rcfile={toxinidir}/.pylintrc qiskit_experiments/ test/ tools/
-  python {toxinidir}/tools/verify_headers.py
-
-[testenv:lint-incr]
-envdir = .tox/lint
-basepython = python3
-allowlist_externals = git
-commands =
-  black --check {posargs} qiskit_experiments test tools setup.py
-  -git fetch -q https://github.com/Qiskit-Extensions/qiskit-experiments :lint_incr_latest
-  python {toxinidir}/tools/pylint_incr.py -rn {posargs} -sn --paths :/qiskit_experiments/*.py :/test/*.py :/tools/*.py
-  python {toxinidir}/tools/verify_headers.py qiskit_experiments test tools
-
-[testenv:black]
-envdir = .tox/lint
-commands = black {posargs} qiskit_experiments test tools setup.py
+alternative_commands =
+  docs =
+    sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
 [testenv:docs]
+runner = alternative_commands
 usedevelop = False
 passenv =
   EXPERIMENTS_DEV_DOCS
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
+allowlist_externals =
+  rm
 commands =
   sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
-
-[testenv:docs-parallel]
-usedevelop = False
-passenv =
-  EXPERIMENTS_DEV_DOCS
-  PROD_BUILD
-  RELEASE_STRING
-  VERSION_STRING
-commands =
-  sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
-
-[testenv:docs-minimal]
-usedevelop = False
-passenv =
-  EXPERIMENTS_DEV_DOCS
-  PROD_BUILD
-  RELEASE_STRING
-  VERSION_STRING
-setenv = 
-  QISKIT_DOCS_SKIP_EXECUTE = 1
-commands =
-  sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
-
-[testenv:docs-qiskit-main]
-usedevelop = True
-passenv =
-  EXPERIMENTS_DEV_DOCS
-  PROD_BUILD
-  RELEASE_STRING
-  VERSION_STRING
-deps =
-  git+https://github.com/Qiskit/qiskit
-  -r{toxinidir}/requirements-dev.txt
-  -r{toxinidir}/requirements-extras.txt
-commands =
-  sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
-
-[testenv:docs-clean]
-skip_install = true
-deps =
-allowlist_externals = rm
-commands = rm -rf {toxinidir}/docs/stubs/ {toxinidir}/docs/_build
+alternative_commands =
+  minimal =
+    add_setenv QISKIT_DOCS_SKIP_EXECUTE = 1
+    sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
+  parallel =
+    sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
+  clean =
+    rm -rf {toxinidir}/docs/stubs/ {toxinidir}/docs/_build

--- a/toxfile.py
+++ b/toxfile.py
@@ -1,0 +1,172 @@
+"""
+tox plugin which allows adding an entry called ``alternative_commands`` to a
+tox environment configuration section with different commands to run instead of
+the main ``commands`` entry. The plugin also adds an ``--alt`` command line
+option for selecting the alternative command sets. To use the alternative
+commands, one must specify the runner as ``alternative_commands``.
+
+For example, one might have an environment for running ``black --check`` but
+set up some alternate commands to check the ``black`` help or version (these
+are not exciting use cases but illustrate the plugin features).  To do this one
+would have an environment config entry like
+
+    [testenv:black]
+    runner = alternative_commands
+    skip_install = true
+    setenv =
+        ENVVAR1 = yes
+    deps =
+      black
+    commands = black --check
+    alternative_commands =
+      help =
+        add_setenv ENVVAR2 = no
+        black --help
+      version =
+        black --version
+        python --version
+
+Then instead of the usual invocation of
+
+    tox run -eblack
+
+one could use
+
+    tox run -eblack --alt help
+
+to print the black help text.
+
+In addition to overriding commands, ``alternative_commands`` entries can also
+include ``add_setenv`` lines which get filtered out from the commands and used
+to add extra variables to the ``setenv`` configuration of the test environment.
+For example, in the ``--alt help`` example, in addition to ``ENVVAR1`` being
+set to ``yes``, ``ENVVAR2`` will be set to ``no``.
+"""
+from __future__ import annotations
+
+from tox.config.cli.parser import ToxParser
+from tox.config.loader.api import Override
+from tox.config.loader.stringify import stringify
+from tox.plugin import impl
+from tox.tox_env.python.virtual_env.runner import VirtualEnvRunner
+from tox.tox_env.register import ToxEnvRegister
+
+
+@impl
+def tox_register_tox_env(register: ToxEnvRegister) -> None:
+    """Register the ``AlternativeCommandsRunner`` tox environment type"""
+    register.add_run_env(AlternativeCommandsRunner)
+
+
+@impl
+def tox_add_option(parser: ToxParser):
+    """Add the ``--alt-command`` command line option"""
+    parser.add_argument("--alt", "--alt-command", default="", dest="alt_command")
+
+
+class AlternativeCommandsRunner(VirtualEnvRunner):
+    """tox environment type that can run alternative commands
+
+    Modified ``VirtualEnvRunner`` that can override settings if the
+    ``--alt-command`` option is used with an argument that matches an
+    alternative command set in the test environment configuration. See the
+    module docstring for more information.
+    """
+
+    def register_config(self):
+        self.conf.add_config(
+            keys=["alternative_commands"],
+            of_type=str,
+            default="",
+            desc="Alternative command sets that can be selected from command line",
+        )
+        super().register_config()
+        alt_cmd = self.options.alt_command
+        if alt_cmd:
+            alt_commands = self.parse_alternative_commands()
+            if alt_cmd in alt_commands:
+                # It would be nice to warn here if alt_cmd is not in
+                # alt_commands, but register_config gets called for every
+                # environment before the selected environments are chosen. So
+                # register_config could be called for an environment that does
+                # not define alt_cmd. More work would be needed to make sure a
+                # warning were only emitted when alt_cmd is not defined for the
+                # selected environments.
+                self.conf.loaders[0].overrides["commands"] = Override(
+                    "commands=" + stringify(alt_commands[alt_cmd]["commands"])[0]
+                )
+                if alt_commands[alt_cmd].get("add_setenv"):
+                    orig_setenv = self.conf.load("setenv")
+                    orig_setenv.update(alt_commands[alt_cmd]["add_setenv"])
+                    self.conf.loaders[0].overrides["setenv"] = Override(
+                        "setenv=" + stringify(orig_setenv)[0]
+                    )
+
+    @staticmethod
+    def id() -> str:
+        return "alternative_commands"
+
+    def parse_alternative_commands(self) -> dict[str, list[str]]:
+        """Parse the alternative_commands config entry
+
+        We turn an entry like
+
+            alternative_commands =
+              set1 =
+                add_setenv OMP_NUM_THREADS = 1
+                add_setenv RAYON_NUM_THREADS = 1
+                cmd1 arg1
+                cmd2 arg2
+              set2 =
+                cmd3 arg3
+                cmd4 arg4
+
+        which gets rendered a newline separated string into a dictionary like
+
+            {
+                "set1": {
+                    "add_setenv": {
+                        "OMP_NUM_THREADS": "1",
+                        "RAYON_NUM_THREADS": "1",
+                    },
+                    "commands": [
+                        "cmd1 arg1",
+                        "cmd2 arg2",
+                    ],
+                },
+                "set2": {
+                    "commands": [
+                        "cmd3 arg3",
+                        "cmd4 arg4",
+                    ],
+                },
+            }
+
+        We don't parse the commands because we pass them as a config override
+        and the config loader wants to load the override as a single string,
+        not as a parsed list of Command objects.
+        """
+        alternative_commands = self.conf["alternative_commands"]
+
+        output = {}
+        name = ""
+        for line in alternative_commands.splitlines():
+            line = line.strip()
+            if line.endswith("="):
+                name = line[:-1].strip()
+                continue
+
+            if not name:
+                raise ValueError(f"Badly formed alternative_commands: {alternative_commands}")
+            if line:
+                alt_entry = output.setdefault(name, {})
+                if line.startswith("add_setenv"):
+                    subline = line[len("add_setenv") :].strip()
+                    key, sep, value = subline.partition("=")
+                    if not sep:
+                        raise ValueError(f"Badly formed add_setenv: {subline}")
+                    alt_entry.setdefault("add_setenv", {})[key.strip()] = value.strip()
+                else:
+                    alt_entry.setdefault("commands", []).append(line)
+
+        return output


### PR DESCRIPTION
This change adds a tox plugin in `toxfile.py` which allows for sets of commands to be mapped to names in the test environment configuration. Additionally, a command line option is added to `tox` which allows one of these command sets to be selected by name and run in place of the default `commands` entry. With this alternative commands feature, several of the test environments that were in `tox.ini` were consolidated into three remaining environments with different sets of commands. The remaining environments are:

* The main Python test environment used for tests, linting, etc.
* The docs environment, needed because of a Sphinx bug that prevents a development install of `qiskit-experiments` from working on macOS.
* The test environment that uses the Qiskit `main` branch instead of the released package.