### PR TITLE
fix level 1 meas with sampler

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1067,7 +1067,6 @@ class ExperimentData:
                         # different parameter binds which is trivial because
                         # qiskit-experiments does not support parameter binding
                         # to pubs currently.
-                        joined_data = joined_data[0]
                         if joined_data.ndim == 1:
                             data["meas_return"] = "avg"
                             # TODO: we either need to track shots in the


### PR DESCRIPTION
this fix is relevant only to experiments with measurement level 1 using Sampler.
Tested on qiskit-monitoring experiments and works fine
