### PR TITLE
Deprecate pulse and restless related experiments and classes

### DIFF
--- a/docs/manuals/characterization/stark_experiment.rst
+++ b/docs/manuals/characterization/stark_experiment.rst
@@ -1,6 +1,14 @@
 AC Stark Effect
 ===============
 
+.. caution::
+
+   The experiments described in this manual are deprecated as of Qiskit
+   Experiments 0.8 and will be removed in a future release. They rely on Qiskit
+   Pulse, which is `deprecated in Qiskit SDK
+   <https://github.com/Qiskit/qiskit/issues/13063>`_, with planned removal in
+   Qiskit 2.0.
+
 When a qubit is driven with an off-resonant tone,
 the qubit frequency :math:`f_0` is slightly shifted through what is known as the (AC) Stark effect.
 This technique is sometimes used to characterize qubit properties in the vicinity of
@@ -144,6 +152,14 @@ by a variant of the Hahn-echo pulse sequence [5]_.
     :hide-code:
 
     %matplotlib inline
+
+    import warnings
+
+    warnings.filterwarnings(
+        "ignore",
+        message=".*Due to the deprecation of Qiskit Pulse.*",
+        category=DeprecationWarning,
+    )
 
     from qiskit_experiments.library import StarkRamseyXY
     from qiskit import schedule, pulse

--- a/docs/manuals/measurement/restless_measurements.rst
+++ b/docs/manuals/measurement/restless_measurements.rst
@@ -1,6 +1,11 @@
 Restless Measurements
 =====================
 
+.. caution::
+
+   Support for restless measurements is deprecated as of Qiskit Experiments 0.8
+   and will be removed in a future version.
+
 When running circuits, the qubits are typically reset to the ground state after
 each measurement to ensure that the next circuit has a well-defined initial state.
 This can be done passively by waiting several :math:`T_1`-times so that qubits in
@@ -64,6 +69,14 @@ they use always starts with the qubits in the ground state.
 
 .. jupyter-execute::
     :hide-code:
+
+    import warnings
+
+    warnings.filterwarnings(
+        "ignore",
+        message=".*Support for restless.*",
+        category=DeprecationWarning,
+    )
 
     # Temporary workaround for missing support in Qiskit and qiskit-ibm-runtime
     from qiskit_experiments.test.patching import patch_sampler_test_support

--- a/docs/tutorials/calibrations.rst
+++ b/docs/tutorials/calibrations.rst
@@ -1,6 +1,14 @@
 Calibrations: Schedules and gate parameters from experiments 
 ============================================================
 
+.. caution::
+
+   Support for calibrating pulses is deprecated as of Qiskit Experiments 0.8
+   and will be removed in a future version. There is no alternative support
+   path because Qiskit Pulse is `deprecated in Qiskit SDK
+   <https://github.com/Qiskit/qiskit/issues/13063>`_ with planned removal in
+   Qiskit 2.0.
+
 To produce high fidelity quantum operations, we want to be able to run good gates. The
 calibration module in Qiskit Experiments allows users to run experiments to find the
 pulse shapes and parameter values that maximize the fidelity of the resulting quantum
@@ -32,6 +40,17 @@ This automatic updating can also be disabled using the ``auto_update`` flag.
 .. note::
     This tutorial requires the :mod:`qiskit_dynamics` package to run simulations.
     You can install it with ``python -m pip install qiskit-dynamics``.
+
+.. jupyter-execute::
+    :hide-code:
+
+    import warnings
+
+    warnings.filterwarnings(
+        "ignore",
+        message=".*Due to the deprecation of Qiskit Pulse.*",
+        category=DeprecationWarning,
+    )
 
 .. jupyter-execute::
 

--- a/docs/tutorials/data_processor.rst
+++ b/docs/tutorials/data_processor.rst
@@ -69,6 +69,17 @@ The code below sets up the Rabi experiment.
     You can install it with ``python -m pip install qiskit-dynamics``.
 
 .. jupyter-execute::
+    :hide-code:
+
+    import warnings
+
+    warnings.filterwarnings(
+        "ignore",
+        message=".*Due to the deprecation of Qiskit Pulse.*",
+        category=DeprecationWarning,
+    )
+
+.. jupyter-execute::
 
     import numpy as np
 

--- a/docs/tutorials/visualization.rst
+++ b/docs/tutorials/visualization.rst
@@ -39,6 +39,17 @@ First, we display the default figure from a :class:`.Rabi` experiment as a start
     with ``python -m pip install qiskit-dynamics qiskit-aer qiskit-ibm-runtime``.
 
 .. jupyter-execute::
+    :hide-code:
+
+    import warnings
+
+    warnings.filterwarnings(
+        "ignore",
+        message=".*Due to the deprecation of Qiskit Pulse.*",
+        category=DeprecationWarning,
+    )
+
+.. jupyter-execute::
 
     import numpy as np
 

--- a/qiskit_experiments/calibration_management/basis_gate_library.py
+++ b/qiskit_experiments/calibration_management/basis_gate_library.py
@@ -25,6 +25,7 @@ import numpy as np
 from qiskit.circuit import Parameter
 from qiskit import pulse
 from qiskit.pulse import ScheduleBlock
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit_experiments.calibration_management.calibration_key_types import DefaultCalValue
 from qiskit_experiments.exceptions import CalibrationError
@@ -39,6 +40,14 @@ class BasisGateLibrary(ABC, Mapping):
     # Parameters that do not belong to a schedule, a set of names
     __parameters_without_schedule__ = set()
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, support for pulse "
+            "gate calibrations has been deprecated."
+        ),
+    )
     def __init__(
         self,
         basis_gates: Optional[List[str]] = None,

--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -63,6 +63,14 @@ class Calibrations:
     ScheduleBlock are supported.
     """
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, support for pulse "
+            "gate calibrations has been deprecated."
+        ),
+    )
     def __init__(
         self,
         coupling_map: Optional[List[List[int]]] = None,

--- a/qiskit_experiments/curve_analysis/standard_analysis/resonance.py
+++ b/qiskit_experiments/curve_analysis/standard_analysis/resonance.py
@@ -17,6 +17,8 @@ from typing import List, Union, Optional
 import lmfit
 import numpy as np
 
+from qiskit.utils.deprecation import deprecate_func
+
 import qiskit_experiments.curve_analysis as curve
 from qiskit_experiments.framework import Options
 
@@ -59,6 +61,14 @@ class ResonanceAnalysis(curve.CurveAnalysis):
 
     """
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments and related classses "
+            "involving pulse gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(
         self,
         name: Optional[str] = None,

--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -18,6 +18,7 @@ class unifies data access for various data fields.
 import warnings
 from qiskit.providers.models import PulseBackendConfiguration  # pylint: disable=no-name-in-module
 from qiskit.providers import BackendV1, BackendV2
+from qiskit.utils.deprecation import deprecate_func
 
 
 class BackendData:
@@ -53,6 +54,14 @@ class BackendData:
             return self._backend.name
         return str(self._backend)
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def control_channel(self, qubits):
         """Returns the backend control channel for the given qubits"""
         try:
@@ -67,6 +76,14 @@ class BackendData:
             return []
         return []
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def drive_channel(self, qubit):
         """Returns the backend drive channel for the given qubit"""
         try:
@@ -81,6 +98,14 @@ class BackendData:
             return None
         return None
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def measure_channel(self, qubit):
         """Returns the backend measure channel for the given qubit"""
         try:
@@ -95,6 +120,14 @@ class BackendData:
             return None
         return None
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def acquire_channel(self, qubit):
         """Returns the backend acquire channel for the given qubit"""
         try:
@@ -122,6 +155,15 @@ class BackendData:
         return 1
 
     @property
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        is_property=True,
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def min_length(self):
         """Returns the backend's time constraint minimum duration"""
         try:
@@ -134,6 +176,15 @@ class BackendData:
         return 0
 
     @property
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        is_property=True,
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def pulse_alignment(self):
         """Returns the backend's time constraint pulse alignment"""
         try:
@@ -146,6 +197,15 @@ class BackendData:
         return 1
 
     @property
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        is_property=True,
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def acquire_alignment(self):
         """Returns the backend's time constraint acquire alignment"""
         try:
@@ -212,6 +272,15 @@ class BackendData:
         return None
 
     @property
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        is_property=True,
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def drive_freqs(self):
         """Returns the backend's qubit drive frequencies"""
         if self._v1:
@@ -223,6 +292,15 @@ class BackendData:
         return []
 
     @property
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        is_property=True,
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def meas_freqs(self):
         """Returns the backend's measurement stimulus frequencies.
 

--- a/qiskit_experiments/framework/backend_timing.py
+++ b/qiskit_experiments/framework/backend_timing.py
@@ -16,6 +16,7 @@ from typing import Optional, Union
 
 from qiskit import QiskitError
 from qiskit.providers.backend import Backend
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit_experiments.framework import BackendData
 
@@ -283,6 +284,14 @@ class BackendTiming:
 
         return samples_out
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def round_pulse(
         self, *, time: Optional[float] = None, samples: Optional[Union[int, float]] = None
     ) -> int:
@@ -363,6 +372,14 @@ class BackendTiming:
 
         return self.dt * self.round_delay(time=time, samples=samples)
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, utility functions involving "
+            "pulse like this one have been deprecated."
+        ),
+    )
     def pulse_time(
         self, *, time: Optional[float] = None, samples: Optional[Union[int, float]] = None
     ) -> float:

--- a/qiskit_experiments/framework/restless_mixin.py
+++ b/qiskit_experiments/framework/restless_mixin.py
@@ -15,6 +15,7 @@
 import logging
 from typing import Callable, Sequence, Optional
 from qiskit.qobj.utils import MeasLevel, MeasReturnType
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit.providers import Backend
 from qiskit_experiments.framework import Options
@@ -66,6 +67,11 @@ class RestlessMixin:
     _physical_qubits: Sequence[int]
     _num_qubits: int
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=("Support for restless experiments has been deprecated."),
+    )
     def enable_restless(
         self,
         rep_delay: Optional[float] = None,

--- a/qiskit_experiments/library/characterization/analysis/cr_hamiltonian_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/cr_hamiltonian_analysis.py
@@ -15,6 +15,8 @@
 from typing import List, Dict
 import numpy as np
 
+from qiskit.utils.deprecation import deprecate_func
+
 import qiskit_experiments.curve_analysis as curve
 from qiskit_experiments.framework import AnalysisResultData
 from qiskit_experiments.visualization import PlotStyle
@@ -44,6 +46,14 @@ class CrossResonanceHamiltonianAnalysis(curve.CompositeCurveAnalysis):
 
     """
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments and related classses "
+            "involving pulse gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(self):
         analyses = []
         for control_state in (0, 1):

--- a/qiskit_experiments/library/characterization/analysis/drag_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/drag_analysis.py
@@ -13,10 +13,12 @@
 """DRAG pulse calibration experiment."""
 
 import warnings
-from typing import List, Union
+from typing import List, Optional, Union
 
 import lmfit
 import numpy as np
+
+from qiskit.utils.deprecation import deprecate_func
 
 import qiskit_experiments.curve_analysis as curve
 from qiskit_experiments.framework import ExperimentData
@@ -253,3 +255,33 @@ class DragCalAnalysis(curve.CurveAnalysis):
         self._options.data_subfit_map = data_subfit_map
 
         super()._initialize(experiment_data)
+
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments and related classses "
+            "involving pulse gate calibrations like this one have been deprecated."
+        ),
+    )
+    def __init__(
+        self,
+        models: Optional[List[lmfit.Model]] = None,
+        name: Optional[str] = None,
+    ):
+        """Initialize data fields that are privately accessed by methods.
+
+        Args:
+            models: List of LMFIT ``Model`` class to define fitting functions and
+                parameters. If multiple models are provided, the analysis performs
+                multi-objective optimization where the parameters with the same name
+                are shared among provided models. When multiple models are provided,
+                user must specify the ``data_subfit_map`` value in the analysis options
+                to allocate experimental results to a particular fit model.
+            name: Optional. Name of this analysis.
+        """
+        super().__init__()
+
+        self._models = models or []
+        self._name = name or self.__class__.__name__
+        self._plot_config_cache = {}

--- a/qiskit_experiments/library/characterization/analysis/resonator_spectroscopy_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/resonator_spectroscopy_analysis.py
@@ -12,8 +12,10 @@
 
 """Spectroscopy analysis class for resonators."""
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 import numpy as np
+
+from qiskit.utils.deprecation import deprecate_func
 
 import qiskit_experiments.curve_analysis as curve
 from qiskit_experiments.framework import AnalysisResultData, ExperimentData
@@ -24,6 +26,20 @@ from qiskit_experiments.database_service.device_component import Resonator
 
 class ResonatorSpectroscopyAnalysis(curve.ResonanceAnalysis):
     """Class to analysis resonator spectroscopy."""
+
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments and related classses "
+            "involving pulse gate calibrations like this one have been deprecated."
+        ),
+    )
+    def __init__(
+        self,
+        name: Optional[str] = None,
+    ):
+        super().__init__(name=name)
 
     @classmethod
     def _default_options(cls):

--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -13,6 +13,7 @@
 Cross resonance Hamiltonian tomography.
 """
 
+import warnings
 from typing import List, Tuple, Sequence, Optional, Type
 
 import numpy as np
@@ -20,6 +21,7 @@ from qiskit import pulse, circuit, QuantumCircuit
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.exceptions import QiskitError
 from qiskit.providers import Backend
+from qiskit.utils.deprecation import deprecate_func
 from qiskit_experiments.framework import (
     BaseExperiment,
     BackendTiming,
@@ -134,6 +136,14 @@ class CrossResonanceHamiltonian(BaseExperiment):
         def __init__(self, width: ParameterValueType):
             super().__init__("cr_gate", 2, [width])
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments involving pulse "
+            "gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(
         self,
         physical_qubits: Tuple[int, int],
@@ -176,9 +186,15 @@ class CrossResonanceHamiltonian(BaseExperiment):
         self._gate_cls = cr_gate or self.CRPulseGate
         self._backend_timing = None
 
-        super().__init__(
-            physical_qubits, analysis=CrossResonanceHamiltonianAnalysis(), backend=backend
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="deprecation of Qiskit Pulse",
+                module="qiskit_experiments",
+                category=DeprecationWarning,
+            )
+            analysis = CrossResonanceHamiltonianAnalysis()
+        super().__init__(physical_qubits, analysis=analysis, backend=backend)
         self.set_experiment_options(durations=durations, **kwargs)
 
     @classmethod

--- a/qiskit_experiments/library/characterization/drag.py
+++ b/qiskit_experiments/library/characterization/drag.py
@@ -12,6 +12,7 @@
 
 """Rough drag experiment."""
 
+import warnings
 from typing import Iterable, List, Optional, Sequence
 import numpy as np
 
@@ -20,6 +21,7 @@ from qiskit.circuit import Gate
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
 from qiskit.pulse import ScheduleBlock
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
@@ -67,6 +69,14 @@ class RoughDrag(BaseExperiment, RestlessMixin):
     # section: example
         .. jupyter-execute::
             :hide-code:
+
+            import warnings
+
+            warnings.filterwarnings(
+                "ignore",
+                message=".*Due to the deprecation of Qiskit Pulse.*",
+                category=DeprecationWarning,
+            )
 
             # backend
             from qiskit_experiments.test.pulse_backend import SingleTransmonTestBackend
@@ -120,6 +130,14 @@ class RoughDrag(BaseExperiment, RestlessMixin):
 
         return options
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments involving pulse "
+            "gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(
         self,
         physical_qubits: Sequence[int],
@@ -142,8 +160,15 @@ class RoughDrag(BaseExperiment, RestlessMixin):
             QiskitError: If the schedule does not have a free parameter.
         """
 
-        # Create analysis in finalize to reflect user change to reps
-        super().__init__(physical_qubits, analysis=DragCalAnalysis(), backend=backend)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="deprecation of Qiskit Pulse",
+                module="qiskit_experiments",
+                category=DeprecationWarning,
+            )
+            analysis = DragCalAnalysis()
+        super().__init__(physical_qubits, analysis=analysis, backend=backend)
 
         if betas is not None:
             self.set_experiment_options(betas=betas)

--- a/qiskit_experiments/library/characterization/multi_state_discrimination.py
+++ b/qiskit_experiments/library/characterization/multi_state_discrimination.py
@@ -12,6 +12,7 @@
 
 """Multi state discrimination experiment."""
 
+import warnings
 from typing import Dict, List, Optional, Sequence
 
 from qiskit import QuantumCircuit
@@ -141,6 +142,14 @@ class MultiStateDiscrimination(BaseExperiment):
         Returns:
             A list of circuits preparing the different energy states.
         """
+        warnings.warn(
+            (
+                "Setting pulse schedules for x gates is deprecated  as of "
+                "version 0.8 due to the deprecation of Qiskit Pulse. It will be "
+                "removed in a future release."
+            ),
+            DeprecationWarning,
+        )
         circuits = []
         for level in range(self.experiment_options.n_states):
             circuit = QuantumCircuit(1)

--- a/qiskit_experiments/library/characterization/qubit_spectroscopy.py
+++ b/qiskit_experiments/library/characterization/qubit_spectroscopy.py
@@ -49,6 +49,14 @@ class QubitSpectroscopy(Spectroscopy):
         .. jupyter-execute::
             :hide-code:
 
+            import warnings
+
+            warnings.filterwarnings(
+                "ignore",
+                message=".*Due to the deprecation of Qiskit Pulse.*",
+                category=DeprecationWarning,
+            )
+
             # backend
             from qiskit_experiments.test.pulse_backend import SingleTransmonTestBackend
             backend = SingleTransmonTestBackend(5.2e9,-.25e9, 1e9, 0.8e9, 1e4, noise=True, seed=199)

--- a/qiskit_experiments/library/characterization/rabi.py
+++ b/qiskit_experiments/library/characterization/rabi.py
@@ -21,6 +21,7 @@ from qiskit.qobj.utils import MeasLevel
 from qiskit.providers import Backend
 from qiskit.pulse import ScheduleBlock
 from qiskit.exceptions import QiskitError
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
@@ -60,6 +61,14 @@ class Rabi(BaseExperiment, RestlessMixin):
     # section: example
         .. jupyter-execute::
             :hide-code:
+
+            import warnings
+
+            warnings.filterwarnings(
+                "ignore",
+                message=".*Due to the deprecation of Qiskit Pulse.*",
+                category=DeprecationWarning,
+            )
 
             # backend
             from qiskit_experiments.test.pulse_backend import SingleTransmonTestBackend
@@ -115,6 +124,14 @@ class Rabi(BaseExperiment, RestlessMixin):
 
         return options
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments involving pulse "
+            "gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(
         self,
         physical_qubits: Sequence[int],
@@ -229,6 +246,14 @@ class EFRabi(Rabi):
     # section: example
         .. jupyter-execute::
             :hide-code:
+
+            import warnings
+
+            warnings.filterwarnings(
+                "ignore",
+                message=".*Due to the deprecation of Qiskit Pulse.*",
+                category=DeprecationWarning,
+            )
 
             # backend
             from qiskit_experiments.test.pulse_backend import SingleTransmonTestBackend

--- a/qiskit_experiments/library/characterization/resonator_spectroscopy.py
+++ b/qiskit_experiments/library/characterization/resonator_spectroscopy.py
@@ -12,6 +12,7 @@
 
 """Spectroscopy experiment class for resonators."""
 
+import warnings
 from typing import Iterable, Optional, Sequence, Tuple
 import numpy as np
 
@@ -176,7 +177,14 @@ class ResonatorSpectroscopy(Spectroscopy):
             QiskitError: If no frequencies are given and absolute frequencies are desired and
                 no backend is given or the backend does not have default measurement frequencies.
         """
-        analysis = ResonatorSpectroscopyAnalysis()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="deprecation of Qiskit Pulse",
+                module="qiskit_experiments",
+                category=DeprecationWarning,
+            )
+            analysis = ResonatorSpectroscopyAnalysis()
 
         if frequencies is None:
             frequencies = np.linspace(-20.0e6, 20.0e6, 51)

--- a/qiskit_experiments/library/characterization/spectroscopy.py
+++ b/qiskit_experiments/library/characterization/spectroscopy.py
@@ -12,6 +12,7 @@
 
 """Abstract spectroscopy experiment base class."""
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import Iterable, Optional, Sequence
 
@@ -20,6 +21,7 @@ from qiskit import QuantumCircuit
 from qiskit.exceptions import QiskitError
 from qiskit.providers import Backend
 from qiskit.qobj.utils import MeasLevel
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit_experiments.framework import BaseAnalysis, BaseExperiment, Options
 from qiskit_experiments.curve_analysis import ResonanceAnalysis
@@ -60,6 +62,14 @@ class Spectroscopy(BaseExperiment, ABC):
 
         return options
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments involving pulse "
+            "gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(
         self,
         physical_qubits: Sequence[int],
@@ -84,7 +94,14 @@ class Spectroscopy(BaseExperiment, ABC):
             QiskitError: If there are less than three frequency shifts.
 
         """
-        analysis = analysis or ResonanceAnalysis()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="deprecation of Qiskit Pulse",
+                module="qiskit_experiments",
+                category=DeprecationWarning,
+            )
+            analysis = analysis or ResonanceAnalysis()
 
         super().__init__(physical_qubits, analysis=analysis, backend=backend)
 

--- a/qiskit_experiments/library/driven_freq_tuning/p1_spect.py
+++ b/qiskit_experiments/library/driven_freq_tuning/p1_spect.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 
 import numpy as np
@@ -20,6 +21,7 @@ from qiskit import pulse
 from qiskit.circuit import QuantumCircuit, Gate, Parameter, ParameterExpression
 from qiskit.providers.backend import Backend
 from qiskit.utils import optionals as _optional
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit_experiments.framework import BackendTiming, BaseExperiment, Options
 from .p1_spect_analysis import StarkP1SpectAnalysis
@@ -72,6 +74,14 @@ class StarkP1Spectroscopy(BaseExperiment):
 
     """
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments involving pulse "
+            "gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(
         self,
         physical_qubits: Sequence[int],
@@ -89,9 +99,18 @@ class StarkP1Spectroscopy(BaseExperiment):
         """
         self._timing = None
 
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="deprecation of Qiskit Pulse",
+                module="qiskit_experiments",
+                category=DeprecationWarning,
+            )
+            analysis = StarkP1SpectAnalysis()
+
         super().__init__(
             physical_qubits=physical_qubits,
-            analysis=StarkP1SpectAnalysis(),
+            analysis=analysis,
             backend=backend,
         )
         self.set_experiment_options(**experiment_options)

--- a/qiskit_experiments/library/driven_freq_tuning/p1_spect_analysis.py
+++ b/qiskit_experiments/library/driven_freq_tuning/p1_spect_analysis.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import numpy as np
 from uncertainties import unumpy as unp
 
+from qiskit.utils.deprecation import deprecate_func
+
 import qiskit_experiments.data_processing as dp
 import qiskit_experiments.visualization as vis
 from qiskit_experiments.data_processing.exceptions import DataProcessorError
@@ -47,6 +49,20 @@ class StarkP1SpectAnalysis(BaseAnalysis):
         :class:`qiskit_experiments.library.driven_freq_tuning.StarkRamseyXYAmpScan`
 
     """
+
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments and related classses "
+            "involving pulse gate calibrations like this one have been deprecated."
+        ),
+    )
+    def __init__(self):
+        """Initialize the analysis object."""
+        # Pass through to parent. This method is only here to be decorated by
+        # deprecate_func
+        super().__init__()
 
     @property
     def plotter(self) -> vis.CurvePlotter:

--- a/qiskit_experiments/library/driven_freq_tuning/ramsey.py
+++ b/qiskit_experiments/library/driven_freq_tuning/ramsey.py
@@ -21,6 +21,7 @@ from qiskit import pulse
 from qiskit.circuit import QuantumCircuit, Gate, Parameter
 from qiskit.providers.backend import Backend
 from qiskit.utils import optionals as _optional
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit_experiments.framework import BaseExperiment, Options, BackendTiming
 from qiskit_experiments.library.characterization.analysis import RamseyXYAnalysis
@@ -88,6 +89,14 @@ class StarkRamseyXY(BaseExperiment):
 
     """
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments involving pulse "
+            "gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(
         self,
         physical_qubits: Sequence[int],

--- a/qiskit_experiments/library/driven_freq_tuning/ramsey_amp_scan.py
+++ b/qiskit_experiments/library/driven_freq_tuning/ramsey_amp_scan.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 
 import numpy as np
@@ -20,6 +21,7 @@ from qiskit import pulse
 from qiskit.circuit import QuantumCircuit, Gate, ParameterExpression, Parameter
 from qiskit.providers.backend import Backend
 from qiskit.utils import optionals as _optional
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit_experiments.framework import BaseExperiment, Options, BackendTiming
 from .ramsey_amp_scan_analysis import StarkRamseyXYAmpScanAnalysis
@@ -93,6 +95,14 @@ class StarkRamseyXYAmpScan(BaseExperiment):
 
     """
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments involving pulse "
+            "gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(
         self,
         physical_qubits: Sequence[int],
@@ -109,9 +119,18 @@ class StarkRamseyXYAmpScan(BaseExperiment):
         """
         self._timing = None
 
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="deprecation of Qiskit Pulse",
+                module="qiskit_experiments",
+                category=DeprecationWarning,
+            )
+            analysis = StarkRamseyXYAmpScanAnalysis()
+
         super().__init__(
             physical_qubits=physical_qubits,
-            analysis=StarkRamseyXYAmpScanAnalysis(),
+            analysis=analysis,
             backend=backend,
         )
         self.set_experiment_options(**experiment_options)

--- a/qiskit_experiments/library/driven_freq_tuning/ramsey_amp_scan_analysis.py
+++ b/qiskit_experiments/library/driven_freq_tuning/ramsey_amp_scan_analysis.py
@@ -19,6 +19,8 @@ import lmfit
 import numpy as np
 from uncertainties import unumpy as unp
 
+from qiskit.utils.deprecation import deprecate_func
+
 import qiskit_experiments.curve_analysis as curve
 import qiskit_experiments.visualization as vis
 from qiskit_experiments.framework import ExperimentData, AnalysisResultData
@@ -154,6 +156,14 @@ class StarkRamseyXYAmpScanAnalysis(curve.CurveAnalysis):
 
     """
 
+    @deprecate_func(
+        since="0.8",
+        package_name="qiskit-experiments",
+        additional_msg=(
+            "Due to the deprecation of Qiskit Pulse, experiments and related classses "
+            "involving pulse gate calibrations like this one have been deprecated."
+        ),
+    )
     def __init__(self):
 
         models = [

--- a/releasenotes/notes/deprecate-pulse-2a13fc783985ac27.yaml
+++ b/releasenotes/notes/deprecate-pulse-2a13fc783985ac27.yaml
@@ -1,0 +1,32 @@
+---
+deprecations:
+  - |
+    Experiments involving pulse gate calibrations have been deprecated, due to
+    the upcoming `deprecation of Qiskit Pulse in Qiskit 2.0
+    <https://github.com/Qiskit/qiskit/issues/13063>`_. These experiments
+    include ``QubitSpectroscopy``, ``EFSpectroscopy``, ``Rabi``, ``EFRabi``,
+    ``ResonatorSpectroscopy``, ``RoughDrag``, ``StarkRamseyXY``,
+    ``StarkRamseyXYAmpScan``, ``StarkP1Spectroscopy``,
+    ``CrossResonanceHamiltonian``, ``EchoedCrossResonanceHamiltonian``,
+    ``RoughFrequencyCal``, ``RoughEFFrequencyCal``, ``FrequencyCal``,
+    ``FineFrequencyCal``, ``RoughDragCal``, ``FineXDragCal``,
+    ``FineSXDragCal``, ``FineDragCal``, ``FineAmplitudeCal``,
+    ``FineXAmplitudeCal``, ``FineSXAmplitudeCal``, ``HalfAngleCal``,
+    ``RoughAmplitudeCal``, ``RoughXSXAmplitudeCal``, and
+    ``EFRoughXSXAmplitudeCal``.
+  - |
+    Also due to the deprecation of Qiskit Pulse, support for providing pulse
+    gate calibrations to excite higher levels has been deprecated from
+    :class:`.MultiStateDiscrimination`.
+  - |
+    The ``Calibrations`` class and all of Qiskit Experiments' calibration
+    support is deprecated. The calibrations features were based on adjusting
+    parameters of pulses used in gates. With the deprecation of Qiskit Pulse,
+    these features are now also deprecated.
+  - |
+    Support for running experiments in restless mode using the
+    ``RestlessMixin`` is deprecated. With improvements in the reliability of
+    IBM Quantum's qubit initialization, circuit exectuion has already become
+    reasonably fast and restless measurements do not add much performance
+    improvement. It is expected that the restless features are little used as
+    there has been no recent user feedback about them.

--- a/test/base.py
+++ b/test/base.py
@@ -145,6 +145,20 @@ def create_base_test_case(use_testtools: bool) -> unittest.TestCase:
                 message=".*have no effect in local testing mode.*",
                 category=UserWarning,
             )
+            # All of the pulse related code is going to be removed, so we just
+            # ignore its warnings for now.
+            warnings.filterwarnings(
+                "default",
+                message=".*Due to the deprecation of Qiskit Pulse.*",
+                category=DeprecationWarning,
+            )
+            # All of the restless related code is going to be removed, so we just
+            # ignore its warnings for now.
+            warnings.filterwarnings(
+                "default",
+                message=".*Support for restless experiments has been deprecated.*",
+                category=DeprecationWarning,
+            )
 
             # Some functionality may be deprecated in Qiskit Experiments. If
             # the deprecation warnings aren't filtered, the tests will fail as


### PR DESCRIPTION
This change deprecates the experiments that rely on scanning the parameters of pulses in pulse gate calibrations. Qiskit 2.0 will remove support for pulse gate calibrations, making these experiments impossible to run. The `Calibrations` and `BasisGateLibrary` classes are also deprecated since they have no use without pulse gate calibrations to track. It is planned that Qiskit Pulse will be moved to Qiskit Dynamics and perhaps the experiments and calibrations can be adapted to that use case for calibrating simulated experiments. For now though, this code is removed from Qiskit Experiments to help with making the package more maintainable. Some additional helper code (like the experiments analysis classes and methods of `BackendTiming` and `BackendData`) are also deprecated.

Support for restless experiments is also deprecated with this change. Restless support is distinct from pulse support, but it is deprecated with the same motivation of simplifying the package overall. With improvements in the reliability of IBM Quantum's qubit initialization, circuit exectuion has already become reasonably fast and restless measurements do not add much performance improvement. It is expected that the restless features are little used as there has been no user feedback about them.