### PR TITLE
Address `c_if`, `Permutation`, and `transpile` parameter deprecations in Qiskit 1.3

### DIFF
--- a/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
@@ -300,8 +300,8 @@ def cvxpy_linear_lstsq(
             idx = 0
             for i in range(num_circ_components):
                 for j in range(num_tomo_components):
-                    model = bms_r[idx] @ cvxpy.vec(rhos_r[idx]) - bms_i[idx] @ cvxpy.vec(
-                        rhos_i[idx]
+                    model = bms_r[idx] @ cvxpy.vec(rhos_r[idx], order="F") - bms_i[idx] @ cvxpy.vec(
+                        rhos_i[idx], order="F"
                     )
                     data = probability_data[i, j]
                     args.append(model - data)

--- a/qiskit_experiments/library/tomography/fitters/cvxpy_utils.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_utils.py
@@ -234,8 +234,8 @@ def partial_trace_constaint(
     ptr = partial_trace_super(input_dim, output_dim)
     vec_cons = np.ravel(constraint, order="F")
     return [
-        ptr @ cvxpy.vec(mat_r) == vec_cons.real.round(12),
-        ptr @ cvxpy.vec(mat_i) == vec_cons.imag.round(12),
+        ptr @ cvxpy.vec(mat_r, order="F") == vec_cons.real.round(12),
+        ptr @ cvxpy.vec(mat_i, order="F") == vec_cons.imag.round(12),
     ]
 
 
@@ -274,7 +274,7 @@ def trace_preserving_constaint(
     output_dim = sdim // input_dim
 
     ptr = partial_trace_super(input_dim, output_dim)
-    cons = [ptr @ cvxpy.vec(arg_r) == np.identity(input_dim).ravel()]
+    cons = [ptr @ cvxpy.vec(arg_r, order="F") == np.identity(input_dim).ravel()]
 
     if hermitian:
         return cons
@@ -286,7 +286,7 @@ def trace_preserving_constaint(
         arg_i = mat_i
     else:
         raise TypeError("Input must be a cvxpy variable or list of variables")
-    cons.append(ptr @ cvxpy.vec(arg_i) == np.zeros(input_dim**2))
+    cons.append(ptr @ cvxpy.vec(arg_i, order="F") == np.zeros(input_dim**2))
     return cons
 
 

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -16,7 +16,7 @@ Quantum Tomography experiment
 from typing import Union, Optional, Iterable, List, Tuple, Sequence
 from itertools import product
 from qiskit.circuit import QuantumCircuit, Instruction, ClassicalRegister, Clbit
-from qiskit.circuit.library import Permutation
+from qiskit.circuit.library import PermutationGate
 from qiskit.providers.backend import Backend
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
@@ -278,7 +278,7 @@ class TomographyExperiment(BaseExperiment):
             prep_qargs = list(self._prep_indices)
             if len(self._prep_indices) != total_qubits:
                 prep_qargs += [i for i in range(total_qubits) if i not in self._prep_indices]
-            perm_circ.append(Permutation(total_qubits, prep_qargs).inverse(), range(total_qubits))
+            perm_circ.append(PermutationGate(prep_qargs).inverse(), range(total_qubits))
 
         # Apply original circuit
         if total_clbits:
@@ -291,6 +291,6 @@ class TomographyExperiment(BaseExperiment):
             meas_qargs = list(self._meas_indices)
             if len(self._meas_indices) != total_qubits:
                 meas_qargs += [i for i in range(total_qubits) if i not in self._meas_indices]
-            perm_circ.append(Permutation(total_qubits, meas_qargs), range(total_qubits))
+            perm_circ.append(PermutationGate(meas_qargs), range(total_qubits))
 
         return perm_circ

--- a/releasenotes/notes/qiskit13-deprecations-afece0ceea29f3f7.yaml
+++ b/releasenotes/notes/qiskit13-deprecations-afece0ceea29f3f7.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Minor adjustments were made to Qiskit Experiments internals to avoid
+    deprecation warnings when using Qiskit 1.3. See `#1482
+    <https://github.com/qiskit-community/qiskit-experiments/pull/1482>_`.

--- a/test/library/tomography/tomo_utils.py
+++ b/test/library/tomography/tomo_utils.py
@@ -52,8 +52,10 @@ def teleport_circuit(flatten_creg=True):
     teleport.measure(0, creg[0])
     teleport.measure(1, creg[1])
     # Conditionals
-    teleport.z(2).c_if(creg[0], 1)
-    teleport.x(2).c_if(creg[1], 1)
+    with teleport.if_test((creg[0], True)):
+        teleport.z(2)
+    with teleport.if_test((creg[1], True)):
+        teleport.x(2)
     return teleport
 
 
@@ -76,8 +78,10 @@ def teleport_bell_circuit(flatten_creg=True):
     teleport.h(0)
     teleport.measure(0, creg[0])
     teleport.measure(1, creg[1])
-    teleport.z(2).c_if(creg[0], 1)
-    teleport.x(2).c_if(creg[1], 1)
+    with teleport.if_test((creg[0], True)):
+        teleport.z(2)
+    with teleport.if_test((creg[1], True)):
+        teleport.x(2)
     return teleport
 
 


### PR DESCRIPTION
* `Permutation` instances in tomography experiments have been replaced with `PermutationGate` instances that work the same way for those experiments. The only user facing change should be the avoidance of deprecation warnings in Qiskit 1.3.
* `c_if` usage on conditional gates in some tests has been replaced with `if_test` blocks around those gates.
* `ParallelExperiment` now considers a `target` transpiler option when determining how large a circuit to make when combining subexperiments into a larger circuit. Previously it considered the number of qubits in a `coupling_map` transpiler option or in the experiment's backend.
* Use of `instruction_durations` as a transpile option was replaced with `target` in one test (`instruction_durations` was deprecated as a transpiler parameter).
* Add explicit `order="F"` argument to `cvxpy.vec()` calls. This function started issuing a `FutureWarning` in the latest version of cvxpy about the default order changing from F to C.
