### PR TITLE
Move Provider import only under `TYPE_CHECKING` conditions

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -36,7 +36,7 @@ from matplotlib import pyplot
 from qiskit.result import Result
 from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
 from qiskit.exceptions import QiskitError
-from qiskit.providers import Job, Backend, Provider
+from qiskit.providers import Job, Backend
 from qiskit.utils.deprecation import deprecate_arg
 from qiskit.primitives import BitArray, SamplerPubResult, BasePrimitiveJob
 
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
     # `TYPE_CHECKING` means that the import will never be resolved by an actual
     # interpreter, only static analysis.
     from . import BaseExperiment
+    from qiskit.providers import Provider
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Summary

Qiskit 1.1 deprecated the Provider abstract class to be removed in 2.0 (planned for 1Q2025). In those cases where the class is used for only typechecking purposes, the import should only happen when `TYPE_CHECKING`. For the rest of the cases, I opened https://github.com/qiskit-community/qiskit-experiments/issues/1488
