### PR TITLE
Remove remaining references to Provider classes

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -76,7 +76,6 @@ if TYPE_CHECKING:
     # `TYPE_CHECKING` means that the import will never be resolved by an actual
     # interpreter, only static analysis.
     from . import BaseExperiment
-    from qiskit.providers import Provider
 
 LOG = logging.getLogger(__name__)
 
@@ -173,7 +172,7 @@ class ExperimentData:
         experiment: Optional["BaseExperiment"] = None,
         backend: Optional[Backend] = None,
         service: Optional[IBMExperimentService] = None,
-        provider: Optional[Provider] = None,
+        provider=None,
         parent_id: Optional[str] = None,
         job_ids: Optional[List[str]] = None,
         child_data: Optional[List[ExperimentData]] = None,
@@ -261,7 +260,7 @@ class ExperimentData:
             self._set_backend(backend, recursive=False)
         self.provider = provider
         if provider is None and backend is not None:
-            self.provider = backend.provider
+            self.provider = getattr(backend, "provider", None)
         self._service = service
         if self._service is None and self.provider is not None:
             self._service = self.get_service_from_provider(self.provider)
@@ -675,7 +674,7 @@ class ExperimentData:
         self._set_service(service)
 
     @property
-    def provider(self) -> Optional[Provider]:
+    def provider(self) -> Any:
         """Return the backend provider.
 
         Returns:
@@ -684,7 +683,7 @@ class ExperimentData:
         return self._provider
 
     @provider.setter
-    def provider(self, provider: Provider) -> None:
+    def provider(self, provider: Any) -> None:
         """Set the provider to be used for obtaining job data
 
         Args:
@@ -2369,7 +2368,7 @@ class ExperimentData:
         cls,
         experiment_id: str,
         service: Optional[IBMExperimentService] = None,
-        provider: Optional[Provider] = None,
+        provider: Any = None,
     ) -> "ExperimentData":
         """Load a saved experiment data from a database service.
 

--- a/qiskit_experiments/test/fake_backend.py
+++ b/qiskit_experiments/test/fake_backend.py
@@ -13,7 +13,7 @@
 """Fake backend class for tests."""
 import uuid
 from qiskit.circuit.library import Measure
-from qiskit.providers import ProviderV1
+from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import BackendV2
 from qiskit.providers.options import Options
 from qiskit.transpiler import Target
@@ -23,12 +23,28 @@ from qiskit.result import Result
 from qiskit_experiments.test.utils import FakeJob
 
 
-class FakeProvider(ProviderV1):
+class FakeProvider:
     """Fake provider with no backends for testing"""
 
-    def backends(self, name=None, **kwargs):
+    def backends(self, name=None, **kwargs):  # pylint: disable=unused-argument
         """List of available backends. Empty in this case"""
         return []
+
+    def get_backend(self, name=None, **kwargs):
+        """Return a single backend matching the specified filtering.
+
+        Args:
+            name (str): name of the backend.
+            **kwargs: dict used for filtering.
+
+        Returns:
+            Backend: a backend matching the filtering.
+
+        Raises:
+            QiskitError: if no backend could be found or more than one backend
+                matches the filtering criteria.
+        """
+        raise QiskitError("No backend matches the criteria")
 
 
 class FakeBackend(BackendV2):

--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -20,7 +20,7 @@ import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import XGate, SXGate
 from qiskit.result import Result
-from qiskit.providers import BackendV2, Provider, convert_to_target
+from qiskit.providers import BackendV2, convert_to_target
 from qiskit.providers.fake_provider import FakeOpenPulse2Q
 from qiskit.qobj.utils import MeasLevel
 
@@ -40,7 +40,7 @@ class FakeOpenPulse2QV2(BackendV2):
 
     def __init__(
         self,
-        provider: Provider = None,
+        provider=None,
         name: str = None,
         description: str = None,
         online_date: datetime.datetime = None,

--- a/releasenotes/notes/provider-removal-a132799ce755773f.yaml
+++ b/releasenotes/notes/provider-removal-a132799ce755773f.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    All references to ``qiskit.providers.Provider`` have been removed the code
+    base. The provider base classes were deprecated in Qiskit 1.1 with planned
+    removal in Qiskit 2.0. Qiskit Experiments has some support code for working
+    with providers to retrieve job data, but it takes the provider object as
+    input. The only explicit references to the provider classes were in type
+    annotations and test support code under ``qiskit_experiments.test``. The
+    type annotations have been removed and the test code now uses its own class
+    without a parent.


### PR DESCRIPTION
This change is a follow up to 519bb534c134ca9a251f4f92f6abd39f56017341 to remove remaining references to the Provider base classes which were deprecated in Qiskit 1.1. Providers are now unspecified objects that generate backends. As a follow up, work is needed on the `ExperimentData` class to tighten up how it works with providers, especially since the main provider now is `QiskitRuntimeService` from qiskit-ibm-runtime, which already was not actually a `Provider`.