### PR TITLE
Typo in T2* Ramsey Characterization document

### DIFF
--- a/docs/manuals/characterization/t2ramsey.rst
+++ b/docs/manuals/characterization/t2ramsey.rst
@@ -85,7 +85,7 @@ pure T1/T2 relaxation noise model.
     backend = AerSimulator.from_backend(FakePerth(), noise_model=noise_model)
 
 The resulting graph will have the form:
-:math:`f(t) = a * e^{-t/T_2*} \cdot \cos(2 \pi f t + \phi) + b` where *t* is
+:math:`f(t) = a e^{-t/T_2*} \cdot \cos(2 \pi f t + \phi) + b` where *t* is
 the delay, :math:`T_2^\ast` is the decay factor, and *f* is the detuning
 frequency.
 

--- a/docs/manuals/characterization/t2ramsey.rst
+++ b/docs/manuals/characterization/t2ramsey.rst
@@ -85,7 +85,7 @@ pure T1/T2 relaxation noise model.
     backend = AerSimulator.from_backend(FakePerth(), noise_model=noise_model)
 
 The resulting graph will have the form:
-:math:`f(t) = a^{-t/T_2*} \cdot \cos(2 \pi f t + \phi) + b` where *t* is
+:math:`f(t) = a * e^{-t/T_2*} \cdot \cos(2 \pi f t + \phi) + b` where *t* is
 the delay, :math:`T_2^\ast` is the decay factor, and *f* is the detuning
 frequency.
 


### PR DESCRIPTION
### Summary

Typo fixed in T2* Ramsey Characterization document
fixes #1495 