### PR TITLE
Improve handling of circuit execution providers

### DIFF
--- a/qiskit_experiments/framework/__init__.py
+++ b/qiskit_experiments/framework/__init__.py
@@ -93,6 +93,12 @@ Experiment Data Classes
     ExperimentDecoder
     ArtifactData
     FigureData
+    Provider
+    BaseProvider
+    IBMProvider
+    Job
+    BaseJob
+    ExtendedJob
 
 .. _composite-experiment:
 
@@ -154,4 +160,5 @@ from .composite import (
     CompositeAnalysis,
 )
 from .json import ExperimentEncoder, ExperimentDecoder
+from .provider_interfaces import BaseJob, BaseProvider, ExtendedJob, IBMProvider, Job, Provider
 from .restless_mixin import RestlessMixin

--- a/qiskit_experiments/framework/provider_interfaces.py
+++ b/qiskit_experiments/framework/provider_interfaces.py
@@ -1,0 +1,108 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Definitions of interfaces for classes working with circuit execution
+
+Qiskit Experiments tries to maintain the flexibility to work with multiple
+providers of quantum circuit execution, like Qiskit IBM Runtime, Qiskit
+Dynamics, and Qiskit Aer. These different circuit execution providers do not
+follow exactly the same interface. This module provides definitions of the
+subset of the interfaces that Qiskit Experiments needs in order to analyze
+experiment results.
+"""
+
+from __future__ import annotations
+from typing import Protocol, Union
+
+from qiskit.result import Result
+from qiskit.primitives import PrimitiveResult
+from qiskit.providers import Backend, JobStatus
+
+
+class BaseJob(Protocol):
+    """Required interface definition of a job class as needed for experiment data"""
+
+    def cancel(self):
+        """Cancel the job"""
+        raise NotImplementedError
+
+    def job_id(self) -> str:
+        """Return the ID string for the job"""
+        raise NotImplementedError
+
+    def result(self) -> Result | PrimitiveResult:
+        """Return the job result data"""
+        raise NotImplementedError
+
+    def status(self) -> JobStatus | str:
+        """Return the status of the job"""
+        raise NotImplementedError
+
+
+class ExtendedJob(BaseJob, Protocol):
+    """Job interface with methods to support all of experiment data's features"""
+
+    def backend(self) -> Backend:
+        """Return the backend associated with a job"""
+        raise NotImplementedError
+
+    def error_message(self) -> str | None:
+        """Returns the reason the job failed"""
+        raise NotImplementedError
+
+
+Job = Union[BaseJob, ExtendedJob]
+"""Union type of job interfaces supported by Qiskit Experiments"""
+
+
+class BaseProvider(Protocol):
+    """Interface definition of a provider class as needed for experiment data"""
+
+    def job(self, job_id: str) -> Job:
+        """Retrieve a job object using its job ID
+
+        Args:
+            job_id: Job ID.
+
+        Returns:
+            The retrieved job
+        """
+        raise NotImplementedError
+
+
+class IBMProvider(BaseProvider, Protocol):
+    """Provider interface needed for supporting features like IBM Quantum
+
+    This interface is the subset of
+    :class:`~qiskit_ibm_runtime.QiskitRuntimeService` needed for all features
+    of Qiskit Experiments. Another provider could implement this interface to
+    support these features as well.
+    """
+
+    def active_account(self) -> dict[str, str] | None:
+        """Return the IBM Quantum account information currently in use
+
+        This method returns the current account information in a dictionary
+        format. It is used to copy the credentials for use with
+        ``qiskit-ibm-experiment`` without requiring specifying the credentials
+        for the provider and ``qiskit-ibm-experiment`` separately
+        It should include ``"url"`` and ``"token"`` as keys for the
+        authentication to work.
+
+        Returns:
+            A dictionary with information about the account currently in the session.
+        """
+        raise NotImplementedError
+
+
+Provider = Union[BaseProvider, IBMProvider]
+"""Union type of provider interfaces supported by Qiskit Experiments"""

--- a/releasenotes/notes/provider-service-types-47c262d5434047e5.yaml
+++ b/releasenotes/notes/provider-service-types-47c262d5434047e5.yaml
@@ -1,0 +1,23 @@
+---
+fixes:
+  - |
+    Fixed  :class:`~.ExperimentData` not inferring the  credentials for the IBM
+    experiment service from a :class:`~qiskit_ibm_runtime.QiskitRuntimeService`
+    instance as it used to do for ``qiskit-ibm-provider``. Previously, the IBM
+    experiment service was set up in the :class:`~.ExperimentData` constructor,
+    but now it is done on first attempt to use the service, allowing more time
+    for the service to be set explicitly or for other attributes to be set that
+    help with inferring the credentials.
+  - |
+    Fixed a bug where :meth:`.ExperimentData.add_data` would not work when
+    passed a single :class:`qiskit.primitives.PrimitiveResult` object.
+developer:
+  - |
+    Added classes
+    :class:`~qiskit_experiments.framework.BaseJob`,
+    :class:`~qiskit_experiments.framework.ExtendedJob`,
+    :class:`~qiskit_experiments.framework.Job`,
+    :class:`~qiskit_experiments.framework.BaseProvider`,
+    :class:`~qiskit_experiments.framework.IBMProvider`, and
+    :class:`~qiskit_experiments.framework.Provider` to document the interfaces
+    needed by :class:`~.ExperimentData` to work with jobs and results.


### PR DESCRIPTION
This change improves several aspects about the way `ExperimentData` works with "providers." Here "provider" is generalized beyond `qiskit.providers.Provider` to any object which can provide a `Job`-like object with data about an experiment's circuit execution. This generalization is needed because `qiskit-ibm-runtime`, the main provider that Experiments integrates with, does not use the `Provider` class, so

* Replace references to `qiskit.providers.Provider` and `qiskit.providers.Job` with  custom interface definitions using `typing.Protocol`. The new interfaces document the API Experiments needs for working with these objects.
* Improve type hints and type checking related to providers, jobs, and results, using the new protocol classes.
* Infer `IBMExperimentService` authentication parameters from a `qiskit_ibm_runtime.QiskitRuntimeService` instance in the same way that the inference used to work with `qiskit_ibm_provider.IBMProvider`.
* Delay inferring an `IBMExperimentService` from a backend or provider until `ExperimentData` tries to communicate with the experiment service. With the fix to infer the authentication parameters from `QiskitRuntimeService`, this delay is needed to avoid breaking existing code that creates an `ExperimentData` instance and then tries to set a custom experiment service for it, relying on the fact that inferrence did not work for `QiskitRuntimeService`, since setting the service on `ExperimentData` after it has already been set once raises an exception.
* Remove dead code, both helper functions that are not called anywhere in the repository and code paths only relevant to qiskit-ibm-provider, like references to `time_per_step()`. Since `qiskit-ibm-provider` has long been deprecated and unsupported by IBM Quantum, removing support for it is not treated as a breaking change.
* Handle some optional data types better (like result objects that might have a `metadata` attribute).