### PR TITLE
Fix minor typos in docs

### DIFF
--- a/docs/howtos/rerun_analysis.rst
+++ b/docs/howtos/rerun_analysis.rst
@@ -90,7 +90,7 @@ restore it later with the following lines of code:
     from qiskit_experiments.framework import ExperimentDecoder, ExperimentEncoder
 
     serialized_exp = json.dumps(Experiment.config(), cls=ExperimentEncoder)
-    Experiment.from_config(json.loads(serialized_exp), cls=ExperimentDecoder)
+    Experiment.from_config(json.loads(serialized_exp, cls=ExperimentDecoder))
 
 Rerunning with different analysis options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/releasenotes/notes/qiskit13-deprecations-afece0ceea29f3f7.yaml
+++ b/releasenotes/notes/qiskit13-deprecations-afece0ceea29f3f7.yaml
@@ -3,4 +3,4 @@ upgrade:
   - |
     Minor adjustments were made to Qiskit Experiments internals to avoid
     deprecation warnings when using Qiskit 1.3. See `#1482
-    <https://github.com/qiskit-community/qiskit-experiments/pull/1482>_`.
+    <https://github.com/qiskit-community/qiskit-experiments/pull/1482>`__.


### PR DESCRIPTION
* Sphinx link syntax error (`_` in wrong place).
* `)` in wrong place in untested Python code example.