### PR TITLE
Fix tests failing against Qiskit main due to change in delay behavior

### DIFF
--- a/test/library/characterization/test_t1.py
+++ b/test/library/characterization/test_t1.py
@@ -18,6 +18,7 @@ import numpy as np
 from qiskit.circuit import Delay, Parameter
 from qiskit.circuit.library import CXGate, Measure, RXGate
 from qiskit.qobj.utils import MeasLevel
+from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.transpiler import InstructionProperties, Target
 from qiskit_ibm_runtime.fake_provider import FakeAthensV2
 from qiskit_experiments.test.noisy_delay_aer_simulator import NoisyDelayAerBackend
@@ -310,7 +311,8 @@ class TestT1(QiskitExperimentsTestCase):
 
     def test_circuit_roundtrip_serializable(self):
         """Test circuit round trip JSON serialization"""
-        exp = T1([0], [1, 2, 3, 4, 5])
+        backend = GenericBackendV2(num_qubits=2)
+        exp = T1([0], [1, 2, 3, 4, 5], backend=backend)
         self.assertRoundTripSerializable(exp._transpiled_circuits())
 
     def test_analysis_config(self):

--- a/test/library/characterization/test_tphi.py
+++ b/test/library/characterization/test_tphi.py
@@ -14,6 +14,7 @@ Test Tphi experiment.
 """
 from test.base import QiskitExperimentsTestCase
 from qiskit.exceptions import QiskitError
+from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit_experiments.library import Tphi, T2Hahn, T2Ramsey
 from qiskit_experiments.test.noisy_delay_aer_simulator import NoisyDelayAerBackend
 from qiskit_experiments.library.characterization.analysis import (
@@ -146,11 +147,12 @@ class TestTphi(QiskitExperimentsTestCase):
 
     def test_circuits_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = Tphi([0], [1], [2])
+        backend = GenericBackendV2(num_qubits=2)
+        exp = Tphi([0], [1e-6], [2e-6], backend=backend)
         self.assertRoundTripSerializable(exp._transpiled_circuits())
-        exp = Tphi([0], [1], [2], "hahn", 3)
+        exp = Tphi([0], [1e-6], [2e-6], "hahn", 3, backend=backend)
         self.assertRoundTripSerializable(exp._transpiled_circuits())
-        exp = Tphi([0], [1], [2], "ramsey", 0)
+        exp = Tphi([0], [1e-6], [2e-6], "ramsey", 0, backend=backend)
         self.assertRoundTripSerializable(exp._transpiled_circuits())
 
     def test_analysis_config(self):


### PR DESCRIPTION
A long-standing bug in qpy leads to the units of delay instructions being overwritten to `dt`. See:

https://github.com/Qiskit/qiskit/issues/10662

Some experiments test that their circuits are round-trip serializable through qpy (perhaps not as necessary as it once was as the room for sticking arbitrary Python into circuits is reduced with the move to Rust). The T1 and Tphi circuits have delays and so were affected by the qpy bug. However, there is a second bug related to delays which canceled this bug out for those tests. `Delay.__eq__` does not check that the units are the same for the two delay instructions, so the loss of the original unit did not matter for the tests. Following this change:

https://github.com/Qiskit/qiskit/pull/13486

Comparing circuits with delays now includes the delay units in the determination of equality. `Delay.__eq__` itself still does not consider the unit but some part of adding the delay to a circuit converts it into a Rust object that does check the unit.

Here the tests are given a backend with a `dt` value so that the experiments will generate circuits with delays in `dt` and so still have delays with the same `dt` after the qpy roundtrip.