### PR TITLE
Replace backend comparison test with comparison of backend attributes

### DIFF
--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -200,7 +200,30 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         """
         Recursively traverse the tree to verify attributes
         """
-        self.assertEqual(expdata.backend, self.backend)
+        # qiskit-ibm-runtime deepcopies the backend and BackendV2 does not
+        # define a custom __eq__ so we just check the important properties
+        backend_attrs = (
+            "name",
+            "options",
+            "instructions",
+            "operations",
+            "operation_names",
+            "num_qubits",
+            "coupling_map",
+            "dt",
+        )
+        for attr in backend_attrs:
+            self.assertEqual(getattr(expdata.backend, attr), getattr(self.backend, attr))
+        try:
+            self.backend.qubit_properties(list(range(self.backend.num_qubits)))
+        except NotImplementedError:
+            # qubit properties not set
+            pass
+        else:
+            self.assertEqual(
+                expdata.backend.qubit_properties(list(range(self.backend.num_qubits))),
+                self.backend.qubit_properties(list(range(self.backend.num_qubits))),
+            )
         self.assertEqual(expdata.share_level, self.share_level)
 
         components = expdata.child_data()


### PR DESCRIPTION
Starting with qiskit-ibm-runtime 0.35, running circuits with `qiskit_ibm_runtime.SamplerV2` produces jobs whose `backend()` method returns a deepcopy of the original backend object passed to the sampler. Since `BackendV2` does not override `__eq__`, it does not compare equal to a copy of itself and the test that checks that the original backend equals the backend in the experiment data started to fail.

Here the test code is updated to check that the main properties of the backend compare equal rather than comparing the backend objects directly.