### PR TITLE
support RuntimeJobV2 job status

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -118,8 +118,7 @@ def get_job_status(job: Job) -> JobStatus:
                 f"The status of job {job.job_id()} is {status} "
                 "which is not supported by qiskit-experiments."
             )
-        else:
-            status = qe_job_status
+        status = qe_job_status
     return status
 
 

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -107,6 +107,15 @@ def parse_utc_datetime(dt_str: str) -> datetime:
     return dt_utc
 
 
+def get_job_status(job: Job) -> JobStatus:
+    """Get job status in JobStatus format which defined in:
+    `from qiskit.providers.jobstatus import JobStatus`"""
+    status = job.status()
+    if isinstance(status, str):
+        status = getattr(JobStatus, status, JobStatus.DONE)
+    return status
+
+
 class ExperimentData:
     """Experiment data container class.
 
@@ -910,7 +919,7 @@ class ExperimentData:
             return jid, True
         except Exception as ex:  # pylint: disable=broad-except
             # Handle cancelled jobs
-            status = job.status()
+            status = get_job_status(job)
             if status == JobStatus.CANCELLED:
                 LOG.warning("Job was cancelled before completion [Job ID: %s]", jid)
                 return jid, False
@@ -1171,7 +1180,7 @@ class ExperimentData:
         # Add retrieved job objects to stored jobs and extract data
         for jid, job in retrieved_jobs.items():
             self._jobs[jid] = job
-            if job.status() in JOB_FINAL_STATES:
+            if get_job_status(job) in JOB_FINAL_STATES:
                 # Add job results synchronously
                 self._add_job_data(job)
             else:
@@ -1982,7 +1991,7 @@ class ExperimentData:
                 if ids and jid not in ids:
                     # Skip cancelling this callback
                     continue
-                if job and job.status() not in JOB_FINAL_STATES:
+                if job and get_job_status(job) not in JOB_FINAL_STATES:
                     try:
                         job.cancel()
                         LOG.warning("Cancelled job [Job ID: %s]", jid)
@@ -2259,7 +2268,7 @@ class ExperimentData:
             statuses = set()
             for job in self._jobs.values():
                 if job:
-                    statuses.add(job.status())
+                    statuses.add(get_job_status(job))
 
         # If any jobs are in non-DONE state return that state
         for stat in [
@@ -2310,7 +2319,7 @@ class ExperimentData:
 
         # Get any job errors
         for job in self._jobs.values():
-            if job and job.status() == JobStatus.ERROR:
+            if job and get_job_status(job) == JobStatus.ERROR:
                 if hasattr(job, "error_message"):
                     error_msg = job.error_message()
                 else:

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -112,7 +112,14 @@ def get_job_status(job: Job) -> JobStatus:
     `from qiskit.providers.jobstatus import JobStatus`"""
     status = job.status()
     if isinstance(status, str):
-        status = getattr(JobStatus, status, JobStatus.DONE)
+        qe_job_status = getattr(JobStatus, status, None)
+        if qe_job_status is None:
+            raise QiskitError(
+                f"The status of job {job.job_id()} is {status} "
+                "which is not supported by qiskit-experiments."
+            )
+        else:
+            status = qe_job_status
     return status
 
 

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -108,7 +108,7 @@ def parse_utc_datetime(dt_str: str) -> datetime:
 
 
 def get_job_status(job: Job) -> JobStatus:
-    """Get job status in JobStatus format which defined in:
+    """Get job status in JobStatus format defined in:
     `from qiskit.providers.jobstatus import JobStatus`"""
     status = job.status()
     if isinstance(status, str):

--- a/releasenotes/notes/fix-jobv2-status-4cf3443e2f3a16b9.yaml
+++ b/releasenotes/notes/fix-jobv2-status-4cf3443e2f3a16b9.yaml
@@ -2,7 +2,7 @@
 fixes_expdata:
   - |
     Fixed :class:`~.ExperimentData` not reporting the correct job status when
-    the job is of type :class:`~qiskit_ibm_runtime.RuntimeJobV2.
+    the job is of type :class:`~qiskit_ibm_runtime.RuntimeJobV2`.
 developer:
   - |
     Added a function that returns the job status as :class:`qiskit.providers.jobstatus.JobStatus`:

--- a/releasenotes/notes/fix-jobv2-status-4cf3443e2f3a16b9.yaml
+++ b/releasenotes/notes/fix-jobv2-status-4cf3443e2f3a16b9.yaml
@@ -1,7 +1,7 @@
 ---
 fixes_expdata:
   - |
-    Fixed  :class:`~.ExperimentData` not reporting the correct job status when
+    Fixed :class:`~.ExperimentData` not reporting the correct job status when
     the job is of type :class:`~qiskit_ibm_runtime.RuntimeJobV2.
 developer:
   - |

--- a/releasenotes/notes/fix-jobv2-status-4cf3443e2f3a16b9.yaml
+++ b/releasenotes/notes/fix-jobv2-status-4cf3443e2f3a16b9.yaml
@@ -1,0 +1,9 @@
+---
+fixes_expdata:
+  - |
+    Fixed  :class:`~.ExperimentData` not reporting the correct job status when
+    the job is of type :class:`~qiskit_ibm_runtime.RuntimeJobV2.
+developer:
+  - |
+    Added a function that returns the job status as :class:`qiskit.providers.jobstatus.JobStatus`:
+    :func:`~qiskit_experiments.framework.experiment_data.get_job_status`.


### PR DESCRIPTION
The job status definition in `RuntimeJobV2` ([JobStatus](https://github.com/Qiskit/qiskit-ibm-runtime/blob/main/qiskit_ibm_runtime/runtime_job_v2.py#L42-L48)) uses a str object compare to the previous definition in `RuntimeJob` which is an [enum ](https://github.com/Qiskit/qiskit/blob/stable/1.3/qiskit/providers/jobstatus.py#L18-L27). This cause qiskit-experiment to report `JobStatus.DONE` immediately after running an experiment, even if the job was queue/running and a wrong `ExperimentStatus`. 
This change fixes this issue by supporting both definitions, it converts the str `RuntimeJobV2` to the original enum (with the same names). 
