### PR TITLE
Pin Sphinx to <8.2 temporarily to avoid nbsphinx problem

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ nbsphinx
 pylatexenc
 qiskit-sphinx-theme
 reno>=4.1.0
-sphinx>=6.2.1
+sphinx>=6.2.1,<8.2
 sphinx-copybutton
 sphinx-design
 sphinx-remove-toctrees


### PR DESCRIPTION
The currently latest release of nbsphinx (0.9.6) is not compatible with Sphinx 8.2.0, so here Sphinx is pinned to `<8.2`. See:

https://github.com/spatialaudio/nbsphinx/issues/825

The issue is that nbsphinx does `import sphinx` and relies `sphinx` to import all of its submodules which it no longer does.

Note -- qiskit-experiments mainly uses `jupyter-sphinx` now but it still uses the `nbgallery` directive for the landing pages for the tutorials, so it can not simply be dropped as a dependency (maybe the gallery could be formatted without it).

Closes https://github.com/qiskit-community/qiskit-experiments/issues/1513
