### PR TITLE
Layer Fidelity Extensions

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
@@ -155,17 +155,18 @@ class LayerFidelity(BaseExperiment):
             one_qubit_basis_gates: Optional, 1q-gates to use for implementing 1q-Clifford operations.
                             If not specified (but ``backend`` is supplied),
                             all 1q-gates supported in the backend are automatically set.
-            layer_barrier: Optional, enforce a barrier across the whole layer. Default is True
-            which is the defined protocol for layer fidelity. If this is set to false the code runs
-            simultaneous direct 1+2Q RB without a barrier across all qubits.
+            layer_barrier (bool): Optional, enforce a barrier across the whole layer.
+                Default is True, which is the defined protocol for layer fidelity.
+                If this is set to false the code runs
+                simultaneous direct 1+2Q RB without a barrier across all qubits.
             min_delay: Optional. Define a minimum delay in each 2Q layer in units of dt. This
-            delay operation will be applied in any 1Q edge of the layer during the 2Q gate layer
-            in order to enforce a minimum duration of the 2Q layer. This enables some crosstalk
-            testing by removing a gate from the layer without changing the layer duration. If not
-            None then is a list equal in length to the number of two_qubit_layers.  Note that
-            this options requires at least one 1Q edge (a qubit in physical_qubits but
-            not in two_qubit_layers) to be applied. Also will not have an impact on the 2Q gates
-            if layer_barrier=False.
+                delay operation will be applied in any 1Q edge of the layer during the 2Q gate layer
+                in order to enforce a minimum duration of the 2Q layer. This enables some crosstalk
+                testing by removing a gate from the layer without changing the layer duration. If not
+                None then is a list equal in length to the number of two_qubit_layers.  Note that
+                this options requires at least one 1Q edge (a qubit in physical_qubits but
+                not in two_qubit_layers) to be applied. Also will not have an impact on the 2Q gates
+                if layer_barrier=False.
 
         Raises:
             QiskitError: If any invalid argument is supplied.
@@ -269,13 +270,15 @@ class LayerFidelity(BaseExperiment):
             one_qubit_basis_gates (Tuple[str]): One-qubit gates to use for implementing 1q Cliffords.
             clifford_synthesis_method (str): The name of the Clifford synthesis plugin to use
                 for building circuits of RB sequences.
-            layer_barrier (bool): Optional, enforce a barrier across the whole layer. Default is True
-            which is the defined protocol for layer fidelity. If this is set to false the code runs
-            simultaneous direct 1+2Q RB without a barrier across all qubits.
-            min_delay (List[int]): Optional. Define a minimum delay in each 2Q layer in units of dt. This
-            delay operation will be applied in any 1Q edge of the layer during the 2Q gate layer
-            in order to enforce a minimum duration of the 2Q layer. This enables some crosstalk
-            testing by removing a gate from the layer without changing the layer duration.
+            layer_barrier (bool): Optional, enforce a barrier across the whole layer.
+                Default is True, which is the defined protocol for layer fidelity.
+                If this is set to false the code runs
+                simultaneous direct 1+2Q RB without a barrier across all qubits.
+            min_delay (List[int]): Optional. Define a minimum delay in each 2Q layer in units of dt.
+                This delay operation will be applied in any 1Q edge of the layer during
+                the 2Q gate layer in order to enforce a minimum duration of the 2Q layer.
+                This enables some crosstalk testing by removing a gate from the layer without
+                changing the layer duration.
         """
         options = super()._default_experiment_options()
         options.update_options(

--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
@@ -390,6 +390,11 @@ class LayerFidelity(BaseExperiment):
                 composite_clbits.extend(
                     [(c,) for c in range(2 * num_2q_gates, 2 * num_2q_gates + num_1q_gates)]
                 )
+
+                if self.min_delay is None:
+                    min_delay = None
+                else:
+                    min_delay = self.min_delay[i_set]
                 
                 for length in opts.lengths:
                     circ = QuantumCircuit(num_qubits, num_qubits)
@@ -415,7 +420,7 @@ class LayerFidelity(BaseExperiment):
                         gate2q,
                         gate2q_cliff,
                         barrier_inst_gate,
-                        self.min_delay[i_set]
+                        min_delay
                     )
                     # add the measurements
                     circ._append(barrier_inst)

--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
@@ -163,8 +163,9 @@ class LayerFidelity(BaseExperiment):
             in order to enforce a minimum duration of the 2Q layer. This enables some crosstalk
             testing by removing a gate from the layer without changing the layer duration. If not
             None then is a list equal in length to the number of two_qubit_layers.  Note that
-            this options requires at least one 1Q edge (a qubit in physical_qubits but not in two_qubit_layers)
-            to be applied. Also will not have an impact on the 2Q gates if layer_barrier=False.
+            this options requires at least one 1Q edge (a qubit in physical_qubits but
+            not in two_qubit_layers) to be applied. Also will not have an impact on the 2Q gates
+            if layer_barrier=False.
 
         Raises:
             QiskitError: If any invalid argument is supplied.

--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity_analysis.py
@@ -147,6 +147,9 @@ class _ProcessFidelityAnalysis(curve.CurveAnalysis):
         alpha = fit_data.ufloat_params["alpha"]
         pf = (1 + (d * d - 1) * alpha) / (d * d)
 
+        # calculate error per layer
+        epl = (1 - alpha) * (d - 1) / d
+
         quality, reason = self._evaluate_quality_with_reason(fit_data)
 
         metadata["qubits"] = self._physical_qubits
@@ -156,6 +159,15 @@ class _ProcessFidelityAnalysis(curve.CurveAnalysis):
             AnalysisResultData(
                 name="ProcessFidelity",
                 value=pf,
+                chisq=fit_data.reduced_chisq,
+                quality=quality,
+                extra=metadata,
+            )
+        )
+        outcomes.append(
+            AnalysisResultData(
+                name="EPL",
+                value=epl,
                 chisq=fit_data.reduced_chisq,
                 quality=quality,
                 extra=metadata,

--- a/releasenotes/notes/layerfid_opt_add-a42d6e727e5d44b9.yaml
+++ b/releasenotes/notes/layerfid_opt_add-a42d6e727e5d44b9.yaml
@@ -1,9 +1,9 @@
 ---
 features:
   - |
-    :class:`.LayerFidelity` has two new options, ``layer_barrier`` and ``min_delay``. 
-    ``layer_barrier`` turns off the barrier between all qubits in the layer, 
+    :class:`.LayerFidelity` has two new options, ``layer_barrier`` and ``min_delay``.
+    ``layer_barrier`` turns off the barrier between all qubits in the layer,
     so that layer run becomes simultaneous direct RB. ``min_delay`` allows the
-     user to enforce a minimum delay during the two-qubit layer using a qubit 
-     that is not part of the two-qubit gate list. Also added the EPL 
-     (error per layer) calculation to the layer analysis output and to the figure. 
+    user to enforce a minimum delay during the two-qubit layer using a qubit
+    that is not part of the two-qubit gate list. Also added the EPL
+    (error per layer) calculation to the layer analysis output and to the figure.

--- a/releasenotes/notes/layerfid_opt_add-a42d6e727e5d44b9.yaml
+++ b/releasenotes/notes/layerfid_opt_add-a42d6e727e5d44b9.yaml
@@ -1,5 +1,5 @@
 ---
-Features:
+features:
   - |
     :class:`.LayerFidelity` has two new options, ``layer_barrier`` and ``min_delay``. 
     ``layer_barrier`` turns off the barrier between all qubits in the layer, 

--- a/releasenotes/notes/layerfid_opt_add-a42d6e727e5d44b9.yaml
+++ b/releasenotes/notes/layerfid_opt_add-a42d6e727e5d44b9.yaml
@@ -1,0 +1,9 @@
+---
+Features:
+  - |
+    :class:`.LayerFidelity` has two new options, ``layer_barrier`` and ``min_delay``. 
+    ``layer_barrier`` turns off the barrier between all qubits in the layer, 
+    so that layer run becomes simultaneous direct RB. ``min_delay`` allows the
+     user to enforce a minimum delay during the two-qubit layer using a qubit 
+     that is not part of the two-qubit gate list. Also added the EPL 
+     (error per layer) calculation to the layer analysis output and to the figure. 


### PR DESCRIPTION
Some extensions to the layer fidelity code to allow more custom layer fidelity experiments.
- Relax the barrier constraint so that the code can perform direct simultaneous RB
- Add a minimum 2Q gate length so that one can force the 2Q layer to have a minimum length (for studying the length dependence of gate error)