### PR TITLE
Remove references to BackendV1 following its removal in Qiskit 2.0

### DIFF
--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -12,12 +12,13 @@
 """
 Backend data access helper class
 
-Since `BackendV1` and `BackendV2` do not share the same interface, this
-class unifies data access for various data fields.
+This class was introduced to unify backend data access to either `BackendV1` and `BackendV2`
+objects, wrapped by an object of this class. With the removal of `BackendV1` in Qiskit 2.0, 
+this class does not serve any useful purpose anymore and should be removed. 
+
+TODO: remove this class 
 """
-import warnings
-from qiskit.providers.models import PulseBackendConfiguration  # pylint: disable=no-name-in-module
-from qiskit.providers import BackendV1, BackendV2
+from qiskit.providers import BackendV2
 
 
 class BackendData:
@@ -27,29 +28,27 @@ class BackendData:
         """Inits the backend and verifies version"""
 
         self._backend = backend
-        self._v1 = isinstance(backend, BackendV1)
+
+        # Before BackendV1 removal, we also had a self._v1 flag. Since the properties
+        # below account for the case that the provided backend is not supported
+        # (i.e not a BackendV2 now) we keep this semantics but with only one flag
         self._v2 = isinstance(backend, BackendV2)
 
         if self._v2:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore", message=".*qiskit.qobj.pulse_qobj.*", category=DeprecationWarning
-                )
-                self._parse_additional_data()
+            self._parse_additional_data()
 
     def _parse_additional_data(self):
         # data specific parsing not done yet in upstream qiskit
-        if hasattr(self._backend, "_conf_dict") and self._backend._conf_dict["open_pulse"]:
+        if (
+            hasattr(self._backend, "_conf_dict") and self._backend._conf_dict["open_pulse"]
+        ):  # remove
             if "u_channel_lo" not in self._backend._conf_dict:
                 self._backend._conf_dict["u_channel_lo"] = []  # to avoid qiskit bug
-            self._pulse_conf = PulseBackendConfiguration.from_dict(self._backend._conf_dict)
 
     @property
     def name(self):
         """Returns the backend name"""
-        if self._v1:
-            return self._backend.name()
-        elif self._v2:
+        if self._v2:
             return self._backend.name
         return str(self._backend)
 
@@ -57,9 +56,7 @@ class BackendData:
     def granularity(self):
         """Returns the backend's time constraint granularity"""
         try:
-            if self._v1:
-                return self._backend.configuration().timing_constraints.get("granularity", 1)
-            elif self._v2:
+            if self._v2:
                 return self._backend.target.granularity
         except AttributeError:
             return 1
@@ -68,30 +65,21 @@ class BackendData:
     @property
     def dt(self):
         """Returns the backend's input time resolution"""
-        if self._v1:
-            try:
-                return self._backend.configuration().dt
-            except AttributeError:
-                return None
-        elif self._v2:
+        if self._v2:
             return self._backend.dt
         return None
 
     @property
     def max_circuits(self):
         """Returns the backend's max experiments value"""
-        if self._v1:
-            return getattr(self._backend.configuration(), "max_experiments", None)
-        elif self._v2:
+        if self._v2:
             return self._backend.max_circuits
         return None
 
     @property
     def coupling_map(self):
         """Returns the backend's coupling map"""
-        if self._v1:
-            return getattr(self._backend.configuration(), "coupling_map", [])
-        elif self._v2:
+        if self._v2:
             coupling_map = self._backend.coupling_map
             if coupling_map is None:
                 return coupling_map
@@ -101,9 +89,7 @@ class BackendData:
     @property
     def version(self):
         """Returns the backend's version"""
-        if self._v1:
-            return getattr(self._backend, "version", None)
-        elif self._v2:
+        if self._v2:
             return self._backend.version
         return None
 
@@ -111,9 +97,7 @@ class BackendData:
     def provider(self):
         """Returns the backend's provider"""
         try:
-            if self._v1:
-                return self._backend.provider()
-            elif self._v2:
+            if self._v2:
                 return self._backend.provider
         except AttributeError:
             return None
@@ -122,9 +106,7 @@ class BackendData:
     @property
     def num_qubits(self):
         """Returns the backend's number of qubits"""
-        if self._v1:
-            return self._backend.configuration().num_qubits
-        elif self._v2:
+        if self._v2:
             # meas_freq_est is currently not part of the BackendV2
             return self._backend.num_qubits
         return None
@@ -138,8 +120,6 @@ class BackendData:
         Returns:
             The T1 value
         """
-        if self._v1:
-            return self._backend.properties().qubit_property(qubit)["T1"][0]
         if self._v2:
             return self._backend.qubit_properties(qubit).t1
         return float("nan")

--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
@@ -22,8 +22,7 @@ from numpy.random.bit_generator import BitGenerator, SeedSequence
 from qiskit.circuit import QuantumCircuit, CircuitInstruction, Barrier, Gate
 from qiskit.circuit.library import get_standard_gate_name_mapping
 from qiskit.exceptions import QiskitError
-from qiskit.providers import BackendV2Converter
-from qiskit.providers.backend import Backend, BackendV1
+from qiskit.providers.backend import Backend
 from qiskit.quantum_info import Clifford
 
 from qiskit_experiments.framework import BaseExperiment, Options
@@ -287,13 +286,8 @@ class LayerFidelity(BaseExperiment):
         )
 
     def _set_backend(self, backend: Backend):
-        """Set the backend V2 for RB experiments since RB experiments only support BackendV2.
-        If BackendV1 is provided, it is converted to V2 and stored.
-        """
-        if isinstance(backend, BackendV1):
-            super()._set_backend(BackendV2Converter(backend, add_delay=True))
-        else:
-            super()._set_backend(backend)
+        """Set the backend V2 for RB experiments since RB experiments only support BackendV2."""
+        super()._set_backend(backend)
         self.__validate_basis_gates()
 
     def __validate_basis_gates(self) -> None:

--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
@@ -25,6 +25,13 @@ from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
 from qiskit.quantum_info import Clifford
 
+try:
+    from qiskit.providers import BackendV2Converter
+    from qiskit.providers.backend import BackendV1
+except ImportError:
+    BackendV1 = None
+    BackendV2Converter = None
+
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.configs import ExperimentConfig
 
@@ -287,7 +294,10 @@ class LayerFidelity(BaseExperiment):
 
     def _set_backend(self, backend: Backend):
         """Set the backend V2 for RB experiments since RB experiments only support BackendV2."""
-        super()._set_backend(backend)
+        if BackendV1 is not None and isinstance(backend, BackendV1):
+            super()._set_backend(BackendV2Converter(backend, add_delay=True))
+        else:
+            super()._set_backend(backend)
         self.__validate_basis_gates()
 
     def __validate_basis_gates(self) -> None:

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -28,6 +28,14 @@ from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend, BackendV2
 from qiskit.quantum_info import Clifford
 from qiskit.quantum_info.random import random_clifford
+from qiskit.transpiler import CouplingMap
+
+try:
+    from qiskit.providers import BackendV2Converter
+    from qiskit.providers.backend import BackendV1
+except ImportError:
+    BackendV1 = None
+    BackendV2Converter = None
 from qiskit_experiments.framework import BaseExperiment, Options
 from .clifford_utils import (
     CliffordUtils,
@@ -209,6 +217,19 @@ class StandardRB(BaseExperiment):
         """Default transpiler options for transpiling RB circuits."""
         return Options(optimization_level=1)
 
+    def _set_backend(self, backend: Backend):
+        """Set the backend V2 for RB experiments since RB experiments only support BackendV2
+        except for simulators. If BackendV1 is provided, it is converted to V2 and stored.
+        """
+        if (
+            BackendV1 is not None
+            and isinstance(backend, BackendV1)
+            and "simulator" not in backend.name()
+        ):
+            super()._set_backend(BackendV2Converter(backend, add_delay=True))
+        else:
+            super()._set_backend(backend)
+
     def circuits(self) -> List[QuantumCircuit]:
         """Return a list of RB circuits.
 
@@ -284,6 +305,13 @@ class StandardRB(BaseExperiment):
                             backend_cmap = reduced
                             # take the first non-global 2q gate if backend has multiple 2q gates
                             break
+                basis_gates = basis_gates if basis_gates else backend_basis_gates
+                coupling_map = coupling_map if coupling_map else backend_cmap
+            elif BackendV1 is not None and isinstance(self.backend, BackendV1):
+                backend_basis_gates = self.backend.configuration().basis_gates
+                backend_cmap = self.backend.configuration().coupling_map
+                if backend_cmap:
+                    backend_cmap = CouplingMap(backend_cmap).reduce(self.physical_qubits)
                 basis_gates = basis_gates if basis_gates else backend_basis_gates
                 coupling_map = coupling_map if coupling_map else backend_cmap
 

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -25,11 +25,9 @@ from numpy.random.bit_generator import BitGenerator, SeedSequence
 
 from qiskit.circuit import CircuitInstruction, QuantumCircuit, Instruction, Barrier, Gate
 from qiskit.exceptions import QiskitError
-from qiskit.providers import BackendV2Converter
-from qiskit.providers.backend import Backend, BackendV1, BackendV2
+from qiskit.providers.backend import Backend, BackendV2
 from qiskit.quantum_info import Clifford
 from qiskit.quantum_info.random import random_clifford
-from qiskit.transpiler import CouplingMap
 from qiskit_experiments.framework import BaseExperiment, Options
 from .clifford_utils import (
     CliffordUtils,
@@ -211,15 +209,6 @@ class StandardRB(BaseExperiment):
         """Default transpiler options for transpiling RB circuits."""
         return Options(optimization_level=1)
 
-    def _set_backend(self, backend: Backend):
-        """Set the backend V2 for RB experiments since RB experiments only support BackendV2
-        except for simulators. If BackendV1 is provided, it is converted to V2 and stored.
-        """
-        if isinstance(backend, BackendV1) and "simulator" not in backend.name():
-            super()._set_backend(BackendV2Converter(backend, add_delay=True))
-        else:
-            super()._set_backend(backend)
-
     def circuits(self) -> List[QuantumCircuit]:
         """Return a list of RB circuits.
 
@@ -295,13 +284,6 @@ class StandardRB(BaseExperiment):
                             backend_cmap = reduced
                             # take the first non-global 2q gate if backend has multiple 2q gates
                             break
-                basis_gates = basis_gates if basis_gates else backend_basis_gates
-                coupling_map = coupling_map if coupling_map else backend_cmap
-            elif isinstance(self.backend, BackendV1):
-                backend_basis_gates = self.backend.configuration().basis_gates
-                backend_cmap = self.backend.configuration().coupling_map
-                if backend_cmap:
-                    backend_cmap = CouplingMap(backend_cmap).reduce(self.physical_qubits)
                 basis_gates = basis_gates if basis_gates else backend_basis_gates
                 coupling_map = coupling_map if coupling_map else backend_cmap
 

--- a/qiskit_experiments/test/utils.py
+++ b/qiskit_experiments/test/utils.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 
 from qiskit.providers.job import JobV1 as Job
 from qiskit.providers.jobstatus import JobStatus
-from qiskit.providers.backend import BackendV1 as Backend
+from qiskit.providers.backend import BackendV2 as Backend
 from qiskit.result import Result
 
 


### PR DESCRIPTION
### Summary

`BackendV1` and related elements are being removed in Qiskit 2.0 (https://github.com/Qiskit/qiskit/pull/13793).  This PR removes references to `BackendV1` and `PulseBackendConfiguration`. 

### Details and comments

- This is blocker for some PRs in Qiskit due to neko failures caused by https://github.com/Qiskit/qiskit-neko/blob/main/qiskit_neko/tests/experiments/test_tomography.py
- No public API change per se, but should we still mention the removal of `BackendV1` support in `BackendData`? 
