### PR TITLE
Use pypa/build and tox-uv in CI testing and publishing

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -26,25 +26,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Pip cache
-        uses: actions/cache@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-
-            ${{ runner.os }}-${{ matrix.python-version }}
-      - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel
-      - name: Install and Run Tests (Windows and Linux)
-        run: tox -e qiskit-main
-        if: runner.os != 'macOS'
-      - name: Install and Run Tests (Macs only)
-        run: tox -e qiskit-main
-        if: runner.os == 'macOS'
-        env:
-          TEST_TIMEOUT: 120
+          enable-cache: true
+          cache-dependency-glob: |
+            **/tox.ini
+            **/pyproject.toml
+          cache-suffix: testsqiskitmain
+      - name: Install and Run Tests
+        run: uvx --with tox-uv tox -e qiskit-main
   docs:
     if: github.repository_owner == 'Qiskit-Community'
     name: docs
@@ -57,17 +48,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - name: Pip cache
-        uses: actions/cache@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-docs-${{ hashFiles('pyproject.toml') }}
+          enable-cache: true
+          cache-dependency-glob: |
+            **/tox.ini
+            **/pyproject.toml
+          cache-suffix: docsqiskitmain
       - name: Install Deps
         run: |
-          python -m pip install -U tox
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
-        run: tox -edocs-qiskit-main
+        run: uvx --with tox-uv tox -edocs-qiskit-main
       - name: Compress Artifacts
         run: |
           mkdir artifacts

--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -18,11 +18,11 @@ jobs:
         python-version: '3.12'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
     - name: Build docs dev
-      run: EXPERIMENTS_DEV_DOCS=1 PROD_BUILD=1 RELEASE_STRING=`git describe` tox -edocs
+      run: EXPERIMENTS_DEV_DOCS=1 PROD_BUILD=1 RELEASE_STRING=`git describe` uvx --with tox-uv tox run -edocs
     - name: Bypass Jekyll Processing # Necessary for setting the correct css path
       run: touch docs/_build/html/.nojekyll
     - name: Deploy

--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -17,15 +17,15 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
     - name: Build docs
       env:
         QISKIT_DOCS_BUILD_TUTORIALS: 'always'
-      run: PROD_BUILD=1 tox -edocs
+      run: PROD_BUILD=1 uvx --with tox-uv tox -edocs
     - name: Bypass Jekyll Processing # Necessary for setting the correct css path
       run: touch docs/_build/html/.nojekyll
     - name: Deploy

--- a/.github/workflows/docs_stable.yml
+++ b/.github/workflows/docs_stable.yml
@@ -17,15 +17,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -U virtualenv setuptools wheel tox
           sudo apt-get install graphviz pandoc
       - name: Build docs stable
         env:
           QISKIT_DOCS_BUILD_TUTORIALS: 'always'
-        run: PROD_BUILD=1 tox -e docs
+        run: PROD_BUILD=1 uvx --with tox-uv tox -e docs
       - name: Bypass Jekyll Processing # Necessary for setting the correct css path
         run: touch docs/_build/html/.nojekyll
       - name: Set current version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,15 +31,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Pip cache
-        uses: actions/cache@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-
-            ${{ runner.os }}-${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: |
+            **/tox.ini
+            **/pyproject.toml
+          cache-suffix: tests
       - name: Stestr cache
         uses: actions/cache@v4
         with:
@@ -48,18 +47,10 @@ jobs:
           restore-keys: |
             stestr-${{ runner.os }}-
             stestr-
-      - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel
-      - name: Install and Run Tests (Windows and Linux)
-        run: tox -e py
-        if: runner.os != 'macOS'
-      - name: Install and Run Tests (Macs only)
-        run: tox -e py
-        if: runner.os == 'macOS'
-        env:
-          TEST_TIMEOUT: 120
+      - name: Install and Run Tests
+        run: uvx --with tox-uv tox --override testenv.package=external run -e py
       - name: Clean up stestr cache
-        run: tox exec -epy -- stestr history remove all
+        run: uvx --with tox-uv tox exec -epy -- stestr history remove all
 
   lint:
     if: github.repository_owner == 'Qiskit-Community'
@@ -67,19 +58,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
-      - name: Pip cache
-        uses: actions/cache@v4
+          python-version: 3.12
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-lint-${{ hashFiles('pyproject.toml') }}
-      - name: Install Deps
-        run: python -m pip install -U tox
+          enable-cache: true
+          cache-dependency-glob: |
+            **/tox.ini
+            **/pyproject.toml
+          cache-suffix: lint
       - name: Run lint
-        run: tox -elint
+        run: uvx --with tox-uv tox run -elint
   docs:
     if: github.repository_owner == 'Qiskit-Community'
     name: docs
@@ -92,17 +84,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - name: Pip cache
-        uses: actions/cache@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-docs-${{ hashFiles('pyproject.toml') }}
+          enable-cache: true
+          cache-dependency-glob: |
+            **/tox.ini
+            **/pyproject.toml
+          cache-suffix: docstest
       - name: Install Deps
         run: |
-          python -m pip install -U tox
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
-        run: tox -edocs-parallel
+        run: uvx --with tox-uv tox run -edocs-parallel
       - name: Compress Artifacts
         run: |
           mkdir artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,12 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install Deps
-        run: pip install -U wheel
+        run: pip install -U build
       - name: Build Artifacts
         run: |
-          python setup.py sdist
-          python setup.py bdist_wheel
+          python -m build
         shell: bash
       - uses: actions/upload-artifact@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,11 +95,23 @@ python when running. Additionally, the environment that tox sets up matches the 
 environment more closely and it runs the tests in parallel (resulting in much faster
 execution). To run tests on all installed supported python versions and lint/style
 checks you can simply run `tox`. Or if you just want to run the tests once for a
-specific python version such as 3.10: `tox -epy310`.
+specific python version such as 3.10: `tox run -epy310`. Using `tox run -epy`
+will run the tests with the same Python version as used to install `tox`.
+
+> [!TIP]
+> Install `tox` with `tox-uv` using `pip install tox tox-uv` (or `uv pip
+> install tox tox-uv`) for a smoother experience working with the Qiskit
+> Experiments `tox` environments. The `tox.ini` file defines several similar
+> environments because `tox` ties an environment to a single set of commands.
+> It can be slow to recreate each of these environments when switching between
+> commands and updating dependencies. `tox-uv` uses
+> [uv](https://docs.astral.sh/uv/) instead of `pip` for package installation.
+> `uv` makes much better use of caching and hardlinking to set up similar
+> environments much more quickly than `pip` does.
 
 If you just want to run a subset of tests you can pass a selection regex to the test
 runner. For example, if you want to run all tests that have "dag" in the test id you can
-run: `tox -- dag`. You can pass arguments directly to the test runner after the bare
+run: `tox run -epy -- dag`. You can pass arguments directly to the test runner after the bare
 `--`. To see all the options on test selection you can refer to the stestr manual:
 https://stestr.readthedocs.io/en/stable/MANUAL.html#test-selection
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,15 +99,16 @@ specific python version such as 3.10: `tox run -epy310`. Using `tox run -epy`
 will run the tests with the same Python version as used to install `tox`.
 
 > [!TIP]
-> Install `tox` with `tox-uv` using `pip install tox tox-uv` (or `uv pip
-> install tox tox-uv`) for a smoother experience working with the Qiskit
-> Experiments `tox` environments. The `tox.ini` file defines several similar
-> environments because `tox` ties an environment to a single set of commands.
-> It can be slow to recreate each of these environments when switching between
-> commands and updating dependencies. `tox-uv` uses
-> [uv](https://docs.astral.sh/uv/) instead of `pip` for package installation.
-> `uv` makes much better use of caching and hardlinking to set up similar
-> environments much more quickly than `pip` does.
+> Install `tox` with [tox-uv](https://github.com/tox-dev/tox-uv) using `pip
+> install tox tox-uv` (or `uv pip install tox tox-uv`) for a smoother
+> experience working with the Qiskit Experiments `tox` environments. The
+> `tox.ini` file defines several similar environments because `tox` ties an
+> environment to a single set of commands.  It can be slow to recreate each of
+> these environments when switching between commands and updating dependencies.
+> When `tox-uv` is installed, `tox` uses [uv](https://docs.astral.sh/uv/)
+> instead of `pip` for package installation.  `uv` makes better use of caching
+> and hardlinking to set up similar environments much more quickly than `pip`
+> does.
 
 If you just want to run a subset of tests you can pass a selection regex to the test
 runner. For example, if you want to run all tests that have "dag" in the test id you can

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = py312,py311,py310,py39,py38,lint
 
 [testenv]
 package = editable
+package_env = .pkg
+wheel_build_env = .pkg
 setenv =
   VIRTUAL_ENV={envdir}
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
@@ -23,6 +25,20 @@ passenv =
   QE_USE_TESTTOOLS
 commands = stestr run {posargs}
 
+[testenv:.pkg]
+# When testenv.package is set to external these settings will be used to build
+# the wheel with pypa/build instead of tox's internal PEP517 support. pypa/build
+# builds the sdist first and then builds the wheel from the sdist while tox
+# builds the wheel directly and can miss packaging problems like a missing entry
+# in MANIFEST.in.
+deps = build
+# tox does not do variable substitution in this environment so we have to write
+# out .tox/dist and clean it explicitly rather than using {envtmpdir}
+package_glob = .tox/dist/*.whl
+commands =
+    python -c "import shutil; shutil.rmtree('.tox/dist', ignore_errors=True)"
+    python -m build -o .tox/dist
+
 [testenv:cover]
 basepython = python3
 setenv =
@@ -34,7 +50,6 @@ commands =
     coverage3 lcov
 
 [testenv:qiskit-main]
-package = editable
 deps =
   {[testenv]deps}
   git+https://github.com/Qiskit/qiskit
@@ -42,15 +57,12 @@ commands = stestr run {posargs}
 
 
 [testenv:lint]
-envdir = .tox/lint
 commands =
   black --check qiskit_experiments test tools
   pylint -rn {posargs} --rcfile={toxinidir}/.pylintrc qiskit_experiments/ test/ tools/
   python {toxinidir}/tools/verify_headers.py
 
 [testenv:lint-incr]
-envdir = .tox/lint
-basepython = python3
 allowlist_externals = git
 commands =
   black --check {posargs} qiskit_experiments test tools
@@ -59,49 +71,36 @@ commands =
   python {toxinidir}/tools/verify_headers.py qiskit_experiments test tools
 
 [testenv:black]
-envdir = .tox/lint
 commands = black {posargs} qiskit_experiments test tools
 
 [testenv:docs]
-package = wheel
 passenv =
   EXPERIMENTS_DEV_DOCS
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
-deps =
-  {[testenv]deps}
-  pyarrow
 setenv = 
   PYDEVD_DISABLE_FILE_VALIDATION = 1
 commands =
   sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
 [testenv:docs-parallel]
-package = wheel
 passenv =
   EXPERIMENTS_DEV_DOCS
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
-deps =
-  {[testenv]deps}
-  pyarrow
 setenv = 
   PYDEVD_DISABLE_FILE_VALIDATION = 1
 commands =
   sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
 [testenv:docs-minimal]
-package= wheel
 passenv =
   EXPERIMENTS_DEV_DOCS
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
-deps =
-  {[testenv]deps}
-  pyarrow
 setenv = 
   QISKIT_DOCS_SKIP_EXECUTE = 1
   PYDEVD_DISABLE_FILE_VALIDATION = 1
@@ -109,7 +108,6 @@ commands =
   sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
 [testenv:docs-qiskit-main]
-package = editable
 passenv =
   EXPERIMENTS_DEV_DOCS
   PROD_BUILD
@@ -118,7 +116,6 @@ passenv =
 deps =
   {[testenv]deps}
   git+https://github.com/Qiskit/qiskit
-  pyarrow
 setenv =
   PYDEVD_DISABLE_FILE_VALIDATION = 1
 commands =
@@ -127,5 +124,4 @@ commands =
 [testenv:docs-clean]
 skip_install = true
 deps =
-allowlist_externals = rm
-commands = rm -rf {toxinidir}/docs/stubs/ {toxinidir}/docs/_build
+commands = python -c "import shutil; shutil.rmtree('{toxinidir}/docs/stubs/', ignore_errors=True); shutil.rmtree('{toxinidir}/docs/_build', ignore_errors=True)"


### PR DESCRIPTION
pypa/build builds an sdist and then a wheel from the sdist which helps
avoid leaving files out of the sdist. Additionally, pypa/build formats
the package file names in the way that PyPI will soon require while
`python setup.py` does not.

Setting up the .pkg environment led to tox errors when `package` was set
to different values in different environments so they were all set to
editable by default but they can be overridden with `--override
testenv.package=wheel`.

Additionally, the shared `.tox/lint` `envdir` in `tox.ini` was dropped
because with `tox` version 4 it resulted in the environment being
rebuilt every time a different command sharing that environment
directory was run (with `tox` 3 the environment was reused). Instead, a
recommendation to use `tox-uv` was added to the documentation. `uv` is
quick at creating similar virtual environments so it allows using many
`tox` environments without worrying about speed or disk space (because
it uses hard links).

Explicit installation of `pyarrow` was removed from `tox.ini` because
Pandas no longer issues a deprecation warning when `pyarrow` is not
installed.

Along with suggesting using `tox-uv` in the documentation, the GitHub
workflows were updated to use `uv` and `tox-uv`.

Also, the version of Python used for running linting and building the
release artifacts was updated from 3.9 to 3.12

Closes https://github.com/qiskit-community/qiskit-experiments/issues/1527