### PR TITLE
Remove the deprecated return_fit_parameters CurveAnalysis option

### DIFF
--- a/qiskit_experiments/curve_analysis/base_curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/base_curve_analysis.py
@@ -36,7 +36,6 @@ from qiskit_experiments.visualization import (
 from .curve_data import CurveFitResult, ParameterRepr
 from .scatter_table import ScatterTable
 
-PARAMS_ENTRY_PREFIX = "@Parameters_"
 DATA_ENTRY_PREFIX = "@Data_"
 
 
@@ -138,8 +137,6 @@ class BaseCurveAnalysis(BaseAnalysis, ABC):
                 fitting model. This is ``False`` by default.
             plot (bool): Set ``True`` to create figure for fit result or ``False`` to
                 not create a figure. This overrides the behavior of ``generate_figures``.
-            return_fit_parameters (bool): (Deprecated) Set ``True`` to return all fit model parameters
-                with details of the fit outcome. Default to ``False``.
             data_processor (Callable): A callback function to format experiment data.
                 This can be a :class:`.DataProcessor`
                 instance that defines the `self.__call__` method.
@@ -191,7 +188,6 @@ class BaseCurveAnalysis(BaseAnalysis, ABC):
         options.plotter = CurvePlotter(MplDrawer())
         options.plot_raw_data = False
         options.plot_residuals = False
-        options.return_fit_parameters = True
         options.data_processor = None
         options.normalization = False
         options.average_method = "shots_weighted"

--- a/qiskit_experiments/curve_analysis/composite_curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/composite_curve_analysis.py
@@ -252,8 +252,6 @@ class CompositeCurveAnalysis(BaseAnalysis):
                 the analysis result.
             plot (bool): Set ``True`` to create figure for fit result.
                 This is ``True`` by default.
-            return_fit_parameters (bool): (Deprecated) Set ``True`` to return all fit model parameters
-                with details of the fit outcome. Default to ``False``.
             extra (Dict[str, Any]): A dictionary that is appended to all database entries
                 as extra information.
         """
@@ -261,7 +259,6 @@ class CompositeCurveAnalysis(BaseAnalysis):
         options.update_options(
             plotter=CurvePlotter(MplDrawer()),
             plot=True,
-            return_fit_parameters=False,
             extra={},
         )
 
@@ -305,9 +302,7 @@ class CompositeCurveAnalysis(BaseAnalysis):
             analysis = source_analysis.copy()
             metadata = analysis.options.extra
             metadata["group"] = analysis.name
-            analysis.set_options(
-                plot=False, extra=metadata, return_fit_parameters=self.options.return_fit_parameters
-            )
+            analysis.set_options(plot=False, extra=metadata)
             results, _ = analysis._run_analysis(experiment_data)
             for res in results:
                 if isinstance(res, ArtifactData):

--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -34,7 +34,7 @@ from qiskit_experiments.framework.containers import FigureType, ArtifactData
 from qiskit_experiments.data_processing.exceptions import DataProcessorError
 from qiskit_experiments.visualization import PlotStyle
 
-from .base_curve_analysis import BaseCurveAnalysis, PARAMS_ENTRY_PREFIX
+from .base_curve_analysis import BaseCurveAnalysis
 from .curve_data import FitOptions, CurveFitResult
 from .scatter_table import ScatterTable
 from .utils import (
@@ -637,17 +637,6 @@ class CurveAnalysis(BaseCurveAnalysis):
         # After the quality is determined, plot can become a boolean flag for whether
         # to generate the figure
         plot_bool = plot == "always" or (plot == "selective" and quality == "bad")
-
-        if self.options.return_fit_parameters:
-            # Store fit status overview entry regardless of success.
-            # This is sometime useful when debugging the fitting code.
-            overview = AnalysisResultData(
-                name=PARAMS_ENTRY_PREFIX + self.name,
-                value=fit_data,
-                quality=quality,
-                extra=self.options.extra,
-            )
-            result_data.append(overview)
 
         if fit_data.success:
             # Add fit data to curve data table

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1707,14 +1707,7 @@ class ExperimentData:
                     auto_save=self._auto_save,
                 )
             )
-        if index == 0 and tmp_df.iloc[0]["name"].startswith("@"):
-            warnings.warn(
-                "Curve fit results have moved to experiment artifacts and will be removed "
-                "from analysis results in a future release. Use "
-                'expdata.artifacts("fit_summary").data to access curve fit results.',
-                DeprecationWarning,
-            )
-        elif isinstance(index, (int, slice)):
+        if isinstance(index, (int, slice)):
             warnings.warn(
                 "Accessing analysis results via a numerical index is deprecated and will be "
                 "removed in a future release. Use the ID or name of the analysis result "

--- a/releasenotes/notes/remove-return-fit-parameters-1c96a70a1bcf99a1.yaml
+++ b/releasenotes/notes/remove-return-fit-parameters-1c96a70a1bcf99a1.yaml
@@ -1,0 +1,12 @@
+---
+upgrade:
+  - |
+    The deprecated analysis option ``return_fit_parameters`` has been removed
+    from :class:`.CurveAnalysis` and :class:`.CompositeCurveAnalysis`. This
+    change means that the fit parameter analysis result that started with
+    ``@Parameters`` will no longer be included in the set of analysis results.
+    Code calling :meth:`.ExperimentData.analysis_results` with a numerical
+    index, rather than a result name or using ``dataframe=True`` (the
+    recommended pattern) may find a different result than it did before. Fit
+    parameters should be accessed using :meth:`.ExperimentData.artifacts` to
+    retrieve the ``fit_parameters`` artifact.


### PR DESCRIPTION
The deprecated analysis option `return_fit_parameters` has been removed
from `CurveAnalysis` and `CompositeCurveAnalysis`. This
change means that the fit parameter analysis result that started with
`@Parameters` will no longer be included in the set of analysis results.
Code calling `ExperimentData.analysis_results` with a numerical
index, rather than a result name or using `dataframe=True` (the
recommended pattern) may find a different result than it did before. Fit
parameters should be accessed using `ExperimentData.artifacts` to
retrieve the `fit_parameters` artifact.