### PR TITLE
Address transpilation option restrictions in Qiskit 2.0

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -286,7 +286,10 @@ class StandardRB(BaseExperiment):
             coupling_map = coupling_map.reduce(self.physical_qubits)
         if not (basis_gates and coupling_map) and self.backend:
             if isinstance(self.backend, BackendV2) and "simulator" in self.backend.name:
-                basis_gates = basis_gates if basis_gates else self.backend.target.operation_names
+                if not basis_gates:
+                    basis_gates = [
+                        op.name for op in self.backend.target.operations if isinstance(op, Gate)
+                    ]
                 coupling_map = coupling_map if coupling_map else None
             elif isinstance(self.backend, BackendV2):
                 gate_ops = [op for op in self.backend.target.operations if isinstance(op, Gate)]


### PR DESCRIPTION
With Qiskit 2.0, transpilation is always performed using a `Target` object internally. The public API still allows passing various options without a target but then builds a target internally from those options. Because the target involves more structure than individual options, some sets of options do not work the way they did previously. Two cases in Experiments needed to be changed, one in the RB experiment and one in a test.

Here are the specific changes:

1. Filter out non-standard basis gates from RB Clifford synthesis

   With Qiskit 2.0, the transpiler complains about being passed non-standard basis gates and suggests that they can only be passed via a target. In the randomized benchmarking experiment code, Clifford gates are individually transpiled for the backend in order to speed up transpilation by passing the backend's basis gates and a reduced coupling map. For a simulator like `qiskit_aer.AerSimulator` there are many additional non-standard gates like `set_density_matrix` in its `Target`. Since these are not needed for the individual Clifford gate transpilation, the RB code was changed so that these extra instructions are filtered out of the basis gates list passed to the transpiler.

2. Set basis gates on AerSimulator on tests specifying coupling_map

   With Qiskit 2.0, the transpiler complains if a coupling map is specified along with a backend that includes 3-qubit gates like `AerSimulator` does by default (it includes gates like `ccx`). Since the affected test did not use 3-qubit gates, the simplest solution was just to specify the gates that the test did need in the `basis_gates` argument to `AerSimulator` so that the 3-qubit gates are no longer included.

See https://github.com/Qiskit/qiskit/issues/14017