### PR TITLE
Split development dependencies into groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,28 +60,29 @@ extras = [
 "clifford.rb_default" = "qiskit_experiments.library.randomized_benchmarking.clifford_synthesis:RBDefaultCliffordSynthesis"
 
 [dependency-groups]
-dev = [
-    # Linters
-    "black~=22.0",
-    "pylint~=3.3.1",
-    "astroid~=3.3.4",  # Must be kept aligned to what pylint wants
-
-    # Test runner tools
-    "coverage>=5.5",
-    "ddt>=1.6.0",
-    "fixtures",
-    "stestr",
-    "testtools",
-
+formatting = ["black~=22.0"]
+devbase = [
     # Extra dependencies for tests/documentation code
-    "multimethod",
     # qiskit-ibm-runtime 0.34 and qiskit 1.3 are needed to pass run options through
     # qiskit_ibm_runtime.SamplerV2 to test backends' backend.run calls.
     # Earlier versions work okay when using physical backends or not passing run
     # options.
     "qiskit-ibm-runtime>=0.34",  # see above
     "qiskit>=1.3",  # see above
-
+]
+testing = [
+    {include-group = "devbase"},
+    # Test runner tools
+    "coverage>=5.5",
+    "ddt>=1.6.0",
+    "fixtures",
+    "stestr",
+    "testtools",
+    # Packages only used in tests
+    "multimethod",
+]
+docs = [
+    {include-group = "devbase"},
     # Documentation tools
     "arxiv",
     "jupyter-sphinx>=0.4.0",
@@ -89,10 +90,23 @@ dev = [
     "pylatexenc",
     "qiskit-sphinx-theme",
     "reno>=4.1.0",
-    "sphinx>=6.2.1,<8.2",
+    "sphinx>=6.2.1",
     "sphinx-copybutton",
     "sphinx-design",
     "sphinx-remove-toctrees",
+]
+linting = [
+    # Linters
+    "pylint~=3.3.1",
+    "astroid~=3.3.4",  # Must be kept aligned to what pylint wants
+    # Test dependencies needed because the test files are linted
+    {include-group = "testing"},
+]
+dev = [
+    {include-group = "docs"},
+    {include-group = "formatting"},
+    {include-group = "linting"},
+    {include-group = "testing"},
 ]
 
 [tool.setuptools.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv =
   PYTHONSAFEPATH=1
 deps =
 dependency_groups =
-  dev
+  testing
 extras =
   extras
 passenv =
@@ -57,6 +57,9 @@ commands = stestr run {posargs}
 
 
 [testenv:lint]
+dependency_groups =
+  formatting
+  linting
 commands =
   black --check qiskit_experiments test tools
   pylint -rn {posargs} --rcfile={toxinidir}/.pylintrc qiskit_experiments/ test/ tools/
@@ -64,6 +67,9 @@ commands =
 
 [testenv:lint-incr]
 allowlist_externals = git
+dependency_groups =
+  formatting
+  linting
 commands =
   black --check {posargs} qiskit_experiments test tools
   -git fetch -q https://github.com/Qiskit-Community/qiskit-experiments :lint_incr_latest
@@ -71,6 +77,9 @@ commands =
   python {toxinidir}/tools/verify_headers.py qiskit_experiments test tools
 
 [testenv:black]
+skip_install = true
+dependency_groups =
+    formatting
 commands = black {posargs} qiskit_experiments test tools
 
 [testenv:docs]
@@ -79,6 +88,8 @@ passenv =
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
+dependency_groups =
+    docs
 setenv = 
   PYDEVD_DISABLE_FILE_VALIDATION = 1
 commands =
@@ -90,6 +101,8 @@ passenv =
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
+dependency_groups =
+    docs
 setenv = 
   PYDEVD_DISABLE_FILE_VALIDATION = 1
 commands =
@@ -101,6 +114,8 @@ passenv =
   PROD_BUILD
   RELEASE_STRING
   VERSION_STRING
+dependency_groups =
+    docs
 setenv = 
   QISKIT_DOCS_SKIP_EXECUTE = 1
   PYDEVD_DISABLE_FILE_VALIDATION = 1
@@ -116,6 +131,8 @@ passenv =
 deps =
   {[testenv]deps}
   git+https://github.com/Qiskit/qiskit
+dependency_groups =
+    docs
 setenv =
   PYDEVD_DISABLE_FILE_VALIDATION = 1
 commands =


### PR DESCRIPTION
Here the development dependencies in the `dev` dependency group are split into subgroups based on purpose. The `dev` group still encompasses all of the development dependencies through `include-group`. The primary benefit of this change is that `tox run -eblack` now only needs to install `black` instead of a full development environment, while the version of `black` remains pinned in a single place in the repo. There may be some marginal benefit to avoiding installing sphinx in the test environment or stestr in the docs environment as well.

Additionally, this change makes some small changes to the development dependencies, removing a pin on the Sphinx version (added because Sphinx extensions had problems with a new Sphinx release) and `pyarrow` (added because Pandas was issuing warnings when it was not installed but has since removed the warning).