### PR TITLE
Suppress warning from qiskit-ibm-runtime about max_circuits

### DIFF
--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -101,7 +101,22 @@ class BackendData:
         if self._v1:
             return getattr(self._backend.configuration(), "max_experiments", None)
         elif self._v2:
-            return self._backend.max_circuits
+            with warnings.catch_warnings():
+                # qiskit-ibm-runtime deprecated max_circuits:
+                # https://github.com/Qiskit/qiskit-ibm-runtime/pull/2166
+                # Suppress the warning so that we don't trigger it for the user
+                # on every experiment run.
+                #
+                # Remove this warning filter if qiskit-ibm-runtime backends
+                # change to reporting max_circuits as None without a warning.
+                warnings.filterwarnings(
+                    "ignore",
+                    message=".*max_circuits is deprecated in qiskit-ibm-runtime.*",
+                    category=DeprecationWarning,
+                )
+                max_circuits = getattr(self._backend, "max_circuits", None)
+
+            return max_circuits
         return None
 
     @property

--- a/qiskit_experiments/framework/backend_data.py
+++ b/qiskit_experiments/framework/backend_data.py
@@ -111,7 +111,7 @@ class BackendData:
                 # change to reporting max_circuits as None without a warning.
                 warnings.filterwarnings(
                     "ignore",
-                    message=".*max_circuits is deprecated in qiskit-ibm-runtime.*",
+                    message=".*qiskit-ibm-runtime.*",
                     category=DeprecationWarning,
                 )
                 max_circuits = getattr(self._backend, "max_circuits", None)


### PR DESCRIPTION
In qiskit-ibm-runtime 0.37, the `max_circuits` property of the package's backends now issues a deprecation warning. Experiments uses `max_circuits` to split jobs preemptively. Whether `max_circuits` is reported as finite or as `None` jobs should still work okay as long as they don't exceed other service limits. We don't want this `max_circuits` warning issued on every experiment run so we suppress internally.