### PR TITLE
Add tools to help with creating a release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -487,8 +487,11 @@ merged to it are bug fixes.
 
 When it is time to release a new minor version of qiskit-experiments, we will:
 
-1.  Create a new tag with the version number and push it to github
-2.  Change the `main` version to the next release version.
+1.  Run `tox run -erelnotes` to move the notes from the previous release into
+    the main release notes file.
+2.  Add a release notes prelude and any final release notes edits.
+3.  Open a PR to `main` with the release notes updates.
+4.  Create a new `X.Y.0` tag from `main` and push it to github.
 
 The release automation processes will be triggered by the new tag and perform the
 following steps:
@@ -497,8 +500,14 @@ following steps:
     branch
 2.  Build and upload binary wheels to PyPI
 3.  Create a github release page with a generated changelog
-4.  Generate a PR on the meta-repository to bump the qiskit-experiments version and
-    meta-package version.
 
-The `stable/*` branches should only receive changes in the form of bug fixes. If you're making a bug fix PR that you believe should be backported to the current stable release, tag it with `backport stable potential`.
+The `stable/*` branches should only receive changes in the form of bug fixes.
+If you're making a bug fix PR that you believe should be backported to the
+current stable release, tag it with `backport stable potential`. Producing a
+new patch releaes can be done just by adding a new tag to the `stabel/*` to
+trigger the release automation.
+
+After a new release is tagged and the automation runs, the version numbers in
+the `main` branch should be updated. This update can be done by running `tox
+run -ebumpversion` and then committing the resulting changes.
 

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -39,7 +39,9 @@ cloning the repository:
     python -m pip install -e "qiskit-experiments[extras]"
 
 The ``-e`` option will keep your installed package up to date as you make or pull new
-changes.
+changes. See also the `contributing document
+<https://github.com/qiskit-community/qiskit-experiments/blob/main/CONTRIBUTING.md>`__
+in the source code repository for more information on developing the package.
 
 Upgrading Qiskit Experiments
 ----------------------------

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Bump package minor version"""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "packaging",
+# ]
+# ///
+
+from pathlib import Path
+from subprocess import run
+
+from packaging.version import Version
+
+
+def replace_text(path: Path, old: str, new: str, count: int = 1):
+    """Replace old string with new in a file
+
+    Args:
+        path: Path to the file to edit
+        old: Old string to replace
+        new: New string to insert
+        count: How many replacements to expect
+
+    Raises:
+        ValueError: the number of replacements does not match ``count``
+    """
+    lines = path.read_text().splitlines()
+
+    match_num = 0
+    for idx, line in enumerate(lines):
+        if old in line:
+            match_num += 1
+            start = line.index(old)
+            lines[idx] = line[:start] + new + line[start + len(old) :]
+
+    if match_num != count:
+        raise ValueError(f"Expected {count} matches for '{old}' in {path} but found {match_num}")
+
+    path.write_text("\n".join(lines) + "\n")
+
+
+def main():
+    """Bump minor version in package files"""
+    proc = run(["git", "rev-parse", "--show-toplevel"], check=True, capture_output=True, text=True)
+    git_root = Path(proc.stdout.strip())
+
+    version_file = git_root / "qiskit_experiments/VERSION.txt"
+    version_str = version_file.read_text().strip()
+    old_version = Version(version_str)
+    old_version_short = f"{old_version.major}.{old_version.minor}"
+    prev_old_version = f"{old_version.major}.{old_version.minor - 1}.0"
+    prev_old_version_short = f"{old_version.major}.{old_version.minor - 1}"
+
+    new_version = f"{old_version.major}.{old_version.minor + 1}.0"
+    new_version_short = f"{old_version.major}.{old_version.minor + 1}"
+
+    version_file.write_text(f"{new_version}\n")
+
+    replace_text(
+        git_root / "docs/release_notes.rst",
+        f":earliest-version: {prev_old_version}",
+        f":earliest-version: {old_version}",
+    )
+    replace_text(
+        git_root / "docs/conf.py",
+        f'release = os.getenv("RELEASE_STRING", "{old_version}")',
+        f'release = os.getenv("RELEASE_STRING", "{new_version}")',
+    )
+    replace_text(
+        git_root / "docs/conf.py",
+        f'version = os.getenv("VERSION_STRING", "{old_version_short}")',
+        f'version = os.getenv("VERSION_STRING", "{new_version_short}")',
+    )
+    replace_text(
+        git_root / ".mergify.yml",
+        f"- stable/{prev_old_version_short}",
+        f"- stable/{old_version_short}",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -90,11 +90,11 @@ def main():
             f"Could not find previous version tag for current version {version}:\n{proc.stdout}"
         )
 
-    print(f"Starting from commit {orig_commit[:8]} (branch {prep_branch})\n")
+    print(f"Starting from commit {orig_commit[:8]} (branch {prep_branch})...\n")
 
     # Switch to previous release to render notes file and get list of
     # individual notes to remove
-    print("Temporarily switching git to previous release commit:")
+    print("Temporarily switching git to previous release commit...")
     run(["git", "-c", "advice.detachedHead=False", "checkout", str(previous_version)], check=True)
     print("")
 
@@ -104,7 +104,7 @@ def main():
     old_note_files = set((git_root / "releasenotes/notes").iterdir())
 
     # Back to prep branch to apply notes updates
-    print(f"Switching git to {prep_branch} branch:")
+    print(f"Switching git to {prep_branch} branch...")
     run(["git", "checkout", prep_branch], check=True)
     print("")
 
@@ -133,7 +133,7 @@ def main():
     )
     print(
         f"Updating {release_notes_file.relative_to(git_root)} to include notes "
-        f"from {previous_version}\n"
+        f"from {previous_version}...\n"
     )
     release_notes_file.write_text(updated_notes)
 
@@ -146,7 +146,7 @@ def main():
             else:
                 print(f"What is this file? {path}")
 
-    print(f"Create a new release note with name starting with prepare-{version}.")
+    print(f"Creating a new release note with name starting with prepare-{version}...")
     run(["reno", "new", f"prepare-{version}"], check=True)
 
     print("\n*********\n")

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+This script does the following:
+
+1. Run `reno report` on most recent version tag *before* the version in
+   `qiskit_experiments/VERSION.txt`.
+2. Copy the `reno` output into the top of `docs/release_notes.rst` (under
+   the header).
+3. Delete any release notes in `releasenotes/notes` that were included in a
+   previous release.
+4. Create a new `prep-<version>` git branch.
+5. Create a new release note file with a name starting with `prep-<version>`.
+
+If it detects a state that it does not expect (like a non-clean working
+directory or a previously existing `prep-<version>` branch), it exits early.
+
+It is expected that this script is run with a clean working directory when the
+repository is ready (other than writing the release notes prelude and making
+any other release notes edits) to tag the next qiskit-experiments release with
+the version in `qiskit_experiments/VERSION.txt`.
+"""
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "packaging",
+# ]
+# ///
+
+# Note that the script requires git and reno as commands on the system path
+
+from pathlib import Path
+from shutil import rmtree
+from subprocess import run
+from textwrap import fill
+
+from packaging.version import InvalidVersion, Version
+
+
+def main():
+    """Prepare minor release"""
+    proc = run(["git", "diff", "--quiet"], check=False, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"Working directory not clean\n{proc.stdout}\n{proc.stderr}")
+
+    proc = run(["git", "rev-parse", "--show-toplevel"], check=True, capture_output=True, text=True)
+    git_root = Path(proc.stdout.strip())
+
+    version_str = (git_root / "qiskit_experiments/VERSION.txt").read_text().strip()
+    version = Version(version_str)
+
+    # Create branch now so we can error early if it already exists
+    prep_branch = f"prep-{version}"
+    proc = run(["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True)
+    orig_commit = proc.stdout.strip()
+    proc = run(["git", "rev-parse", prep_branch], check=False, capture_output=True, text=True)
+    if proc.returncode == 0:
+        # prep branch already exists, maybe from a previous run that failed
+        prep_branch_hash = proc.stdout.strip()
+        if prep_branch_hash != orig_commit:
+            raise RuntimeError(f"Branch {prep_branch} already exists and is not current commit!")
+    else:
+        run(["git", "branch", prep_branch], check=True)
+
+    proc = run(["git", "tag", "--list"], check=True, capture_output=True, text=True)
+    previous_version = None
+    for tag in proc.stdout.splitlines():
+        try:
+            tag_version = Version(tag)
+        except InvalidVersion:
+            continue
+
+        if tag_version < version and (previous_version is None or tag_version > previous_version):
+            previous_version = tag_version
+
+    if previous_version is None:
+        raise RuntimeError(
+            f"Could not find previous version tag for current version {version}:\n{proc.stdout}"
+        )
+
+    # Switch to previous release to render notes file and get list of
+    # individual notes to remove
+    run(["git", "checkout", str(previous_version)], check=True)
+
+    proc = run(["reno", "report"], check=True, capture_output=True, text=True)
+    notes_last_release = proc.stdout
+
+    old_note_files = set((git_root / "releasenotes/notes").iterdir())
+
+    # Back to prep branch to apply notes updates
+    run(["git", "checkout", prep_branch], check=True)
+
+    # Do some surgery to cut note content from current notes file and the file
+    # generated on the last release tag and join the two together with one
+    # header and an updated release-notes directive.
+    release_notes_file = git_root / "docs/release_notes.rst"
+    notes_older = release_notes_file.read_text()
+
+    insert_idx = 0
+    for idx, line in enumerate(notes_older.splitlines()):
+        if line == ".. release-notes::":
+            # +3 = (release-notes line) + (earliest-version option) + (newline)
+            insert_idx = idx + 3
+            break
+    else:
+        raise RuntimeError(f"Could not find release-notes:: directive in {release_notes_file}")
+
+    header_len = 4  # 4 = "===" + "Release Notes" + "===" + (empty line)
+    updated_notes = "\n".join(
+        [
+            *notes_older.splitlines()[:insert_idx],
+            *notes_last_release.splitlines()[header_len:],
+            *notes_older.splitlines()[insert_idx:],
+        ]
+    )
+    release_notes_file.write_text(updated_notes)
+
+    for path in (git_root / "releasenotes/notes").iterdir():
+        if path in old_note_files:
+            if path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                rmtree(path)
+            else:
+                print(f"What is this file? {path}")
+
+    run(["reno", "new", f"prepare-{version}"], check=True)
+
+    print("\n*********\n")
+    print(
+        fill(
+            f"Release notes prepared. Edit the prepare-{version} note to include "
+            "a prelude for the release and then commit changes if they look okay!"
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -142,3 +142,22 @@ commands =
 skip_install = true
 deps =
 commands = python -c "import shutil; shutil.rmtree('{toxinidir}/docs/stubs/', ignore_errors=True); shutil.rmtree('{toxinidir}/docs/_build', ignore_errors=True)"
+
+[testenv:relnotes]
+# Prepare release notes for a new minor release
+skip_install = true
+deps =
+  packaging
+  reno
+dependency_groups =
+commands =
+  python tools/prepare_release.py
+
+[testenv:bumpversion]
+# Prepare release notes for a new minor release
+skip_install = true
+deps =
+  packaging
+dependency_groups =
+commands =
+  python tools/bump_version.py


### PR DESCRIPTION
* Add `tools/prepare_release.py` for rearranging the release notes files to prepare for a new release.
* Add `tools/bump_verison.py` to increment the version numbers in the repo after tagging a new minor release.
* Update documentation to describe using the tools in the release process.