### PR TITLE
Fix cases of passing `basis_gates` or `coupling_map` to `transpile`

### DIFF
--- a/qiskit_experiments/library/characterization/fine_frequency.py
+++ b/qiskit_experiments/library/characterization/fine_frequency.py
@@ -119,13 +119,6 @@ class FineFrequency(BaseExperiment):
 
         return options
 
-    @classmethod
-    def _default_transpile_options(cls) -> Options:
-        """Default transpiler options."""
-        options = super()._default_transpile_options()
-        options.basis_gates = ["sx", "rz", "delay"]
-        return options
-
     def _pre_circuit(self) -> QuantumCircuit:
         """A method that subclasses can override to perform gates before the main sequence."""
         return QuantumCircuit(1)

--- a/releasenotes/notes/fine-freq-basis-gates-0c8d6a6f895b0ed5.yaml
+++ b/releasenotes/notes/fine-freq-basis-gates-0c8d6a6f895b0ed5.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    The :class:`.FineFrequency` experiment was modified so that it no longer sets
+    the ``basis_gates`` in its transpile options to default to the gates used
+    in its ``circuits()`` method. If these gates were already in the backend's
+    target, there should be no change in behavior. If the gates were not in the
+    backend's target, then the experiment would have been producing transpiled
+    circuits that did not match the backend's instruction set and so would not
+    run. The ``basis_gates`` setting was a remnant from the previous support
+    for pulse calibrations for which the calibration experient would use the
+    ``basis_gates`` option to know which pulse gate calibrations to attach to
+    the circuits.

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -986,7 +986,7 @@ class TestBatchTranspileOptions(QiskitExperimentsTestCase):
             # backend. We are specifically testing using different coupling
             # maps on different subexperiments.
             warnings.filterwarnings(
-                "error", message=".*coupling_map.*backend.*", category=UserWarning
+                "ignore", message=".*coupling_map.*backend.*", category=UserWarning
             )
             expdata = self.batch2.run(backend, noise_model=noise_model, shots=1000, memory=True)
         self.assertExperimentDone(expdata)


### PR DESCRIPTION
In Qiskit 2.0, passing a `backend` and `basis_gates` /`coupling_map` to `transpile` triggers a warning about this possible producing inconsistent results. Two cases of this warning are addressed here:

* The `basis_gates` transpile option of `FineFrequency` was removed. Transpilation should use the gates in the backend and not transpile to a predetermined set that might not match the backend. Using a predetermined set worked okay in the past when this experiment was used with features that would attach pulse gate calibrations for the basis gates to the circuits but those features were removed in 0.9.0.
* A filter previously added to ignore this warning for one test was accidentally committed as "error" instead of "ignore" and this was not noticed because the warning only occurs for Qiskit 2.0. The filter is switched to "ignore" here. The test needs to pass different coupling maps to experiments so it has to trigger the warning.