### PR TITLE
Add measure to test circuit to avoid warnings

### DIFF
--- a/test/fake_experiment.py
+++ b/test/fake_experiment.py
@@ -82,4 +82,7 @@ class FakeExperiment(BaseExperiment):
 
     def circuits(self):
         """Fake circuits."""
-        return [QuantumCircuit(len(self.physical_qubits))]
+        circ = QuantumCircuit(len(self.physical_qubits))
+        # Add measurement to avoid warnings about no measurements
+        circ.measure_all()
+        return [circ]

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -346,7 +346,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         exp4 = BatchExperiment([exp3, exp1], flatten_results=False)
         exp5 = ParallelExperiment([exp4, FakeExperiment([4])], flatten_results=False)
         nested_exp = BatchExperiment([exp5, exp3], flatten_results=False)
-        expdata = nested_exp.run(FakeBackend(num_qubits=4))
+        expdata = nested_exp.run(FakeBackend(num_qubits=5))
         self.assertExperimentDone(expdata)
 
     def test_analysis_replace_results_true(self):

--- a/test/framework/test_framework.py
+++ b/test/framework/test_framework.py
@@ -60,7 +60,7 @@ class TestFramework(QiskitExperimentsTestCase):
 
     def test_metadata(self):
         """Test the metadata of a basic experiment."""
-        backend = FakeBackend(num_qubits=2)
+        backend = FakeBackend(num_qubits=3)
         exp = FakeExperiment((0, 2))
         expdata = exp.run(backend)
         self.assertExperimentDone(expdata)


### PR DESCRIPTION
Recently, qiskit-ibm-runtime's `SamplerV2.run` started warning about circuits that do not have any measurements. Here a measurement is added to the circuit of `FakeExperiment` so that all the tests using it do not issue warnings.

Additionally, the number of qubits set on the test backend was corrected in a couple tests. The incorrect qubit number was exposed by transpiler errors after adding the `measure_all()` call that added measurements on higher index qubits than the backend was set to support.