### PR TITLE
Update PR template to match expectations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,14 @@
-### Summary
+> [!WARNING]
+> The PR title and description will be used as the commit message upon merge.
+>
+> **Please delete all content in this template** before merging and keep the
+> description updated if the PR changes.
+>
+> Please keep the description concise and focused on the changes to the content.
+> Secondary discussions, such as intermediate testing and bug statuses that do
+> not affect the final PR, should be in the PR comments.
 
-Please describe what this PR changes as concisely as possible. Link to the issue(s) that this addresses, if any.
-
-### Details and comments
-
-Some details that should be in this section include:
-
-- Why this change was necessary
-- What alternative solutions were considered and why the current solution was chosen
-- What tests and documentation have been added/updated
-- What do users and developers need to know about this change
-
-Note that this entire PR description field will be used as the commit message upon merge, so please keep it updated along with the PR. Secondary discussions, such as intermediate testing and bug statuses that do not affect the final PR, should be in the PR comments.
-
-### PR checklist (delete when all criteria are met)
+*## PR checklist (delete when all criteria are met)
 
 - [ ] I have read the contributing guide `CONTRIBUTING.md`.
 - [ ] I have added the tests to cover my changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,12 +4,13 @@
 > **Please delete all content in this template** before merging and keep the
 > description updated if the PR changes.
 >
-> Please keep the description concise and focused on the changes to the content.
+> Please keep the description concise and focused on the changes to the repository.
 > Secondary discussions, such as intermediate testing and bug statuses that do
 > not affect the final PR, should be in the PR comments.
 
-*## PR checklist (delete when all criteria are met)
+### PR checklist (delete when all criteria are met)
 
+- [ ] I have referenced any relevant issue addressed by this change.
 - [ ] I have read the contributing guide `CONTRIBUTING.md`.
 - [ ] I have added the tests to cover my changes.
 - [ ] I have updated the documentation accordingly.


### PR DESCRIPTION
This change has two goals:

* More prominently emphasize that the PR description becomes the commit message so the template content needs to be deleted.
* Deemphasize making the PR description all encompassing. The previous version of the template had summary and details sections and encouraged talking through alternative solutions considered and how the change affects users. That is a bit much to end up in the final commit message and is better pushed to PR comments or the release notes.