### PR TITLE
Filter non-standard one qubit gates out of LayerFidelity's basis gates

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
@@ -14,6 +14,7 @@ Layer Fidelity RB Experiment class.
 """
 import functools
 import logging
+import warnings
 from typing import Union, Iterable, Optional, List, Sequence, Tuple, Dict
 
 from numpy.random import Generator, default_rng
@@ -202,7 +203,15 @@ class LayerFidelity(BaseExperiment):
             one_qubit_basis_gates = []
             for op in self.backend.target.operations:
                 if isinstance(op, Gate) and op.num_qubits == 1:
-                    one_qubit_basis_gates.append(op.name)
+                    if op.name in GATE_NAME_MAP:
+                        one_qubit_basis_gates.append(op.name)
+                    else:
+                        warnings.warn(
+                            f'Not using single qubit gate "{op.name}". Please '
+                            "open an issue if support for using gates outside "
+                            "of Qiskit's standard gates is needed for layer "
+                            "fidelity."
+                        )
             LOG.info("%s is set for one_qubit_basis_gates", str(one_qubit_basis_gates))
             if not one_qubit_basis_gates:
                 raise QiskitError(

--- a/releasenotes/notes/lf-1q-gates-6402f24811d97d5e.yaml
+++ b/releasenotes/notes/lf-1q-gates-6402f24811d97d5e.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    :class:`.LayerFidelity` now filters out non-standard one qubit gates from
+    the target when choosing the set to use for transpiling the one qubit
+    Clifford gates. Previously, it would use all one qubit gates in the
+    backend's target. With Qiskit 2.0, transpiling with a non-standard gate in
+    the way that :class:`.LayerFidelity` does leads to an exception. A warning
+    is emitted if a non-standard one qubit gate is filtered out.


### PR DESCRIPTION
With this change, `LayerFidelity` now filters out non-standard one qubit gates from the target when choosing the set to use for transpiling the one qubit Clifford gates. Previously, it would use all one qubit gates in the backend's target. With Qiskit 2.0, transpiling with a non-standard gate in the way that `LayerFidelity` does leads to an exception. A warning is emitted if a non-standard one qubit gate is filtered out.