### PR TITLE
Address Qiskit 2.0 linting issues

### DIFF
--- a/qiskit_experiments/test/pulse_backend.py
+++ b/qiskit_experiments/test/pulse_backend.py
@@ -345,8 +345,11 @@ class PulseBackend(BackendV2):
         Returns:
             Time-evolution unitary operator
         """
+        # pylint: disable=import-error,no-name-in-module
         from qiskit.pulse import ScheduleBlock
         from qiskit.pulse.transforms import block_to_schedule
+
+        # pylint: enable=import-error,no-name-in-module
 
         if len(qubits) > 1:
             raise QiskitError("Multi qubit gates are not yet implemented.")
@@ -503,9 +506,12 @@ class SingleTransmonTestBackend(PulseBackend):
             atol: Absolute tolerance during solving.
             rtol: Relative tolerance during solving.
         """
+        # pylint: disable=import-error,no-name-in-module
         from qiskit.providers.models import PulseDefaults  # pylint: disable=no-name-in-module
         from qiskit.providers.models.pulsedefaults import Command
         from qiskit.qobj.pulse_qobj import PulseQobjInstruction
+
+        # pylint: enable=import-error,no-name-in-module
         from qiskit_dynamics.pulse import InstructionToSignals
 
         qubit_frequency_02 = 2 * qubit_frequency + anharmonicity

--- a/test/data_processing/base_data_processor_test.py
+++ b/test/data_processing/base_data_processor_test.py
@@ -46,7 +46,10 @@ class BaseDataProcessorTest(QiskitExperimentsTestCase):
                     message=".*QobjDictField.*",
                     category=DeprecationWarning,
                 )
+                # pylint: disable=import-error,no-name-in-module
                 from qiskit.qobj.common import QobjExperimentHeader
+
+                # pylint: enable=no-name-in-module
 
                 self.header = QobjExperimentHeader(
                     memory_slots=2,


### PR DESCRIPTION
Some parts of the code that retain deprecated features for Qiskit 1.0 are causing pylint errors now that Qiskit 2.0 has been released and is being used in the pylint environment. Here explicit disabling of pylint in those areas is added and can remain until those parts of the code can be removed.