### PR TITLE
Ignore warning about std_dev==0 in ufloat_params

### DIFF
--- a/releasenotes/notes/uncertainties-stddev0-warning-aea55aada131d8b1.yaml
+++ b/releasenotes/notes/uncertainties-stddev0-warning-aea55aada131d8b1.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    Warnings from the `Uncertainties
+    <https://uncertainties.readthedocs.io/en/latest/>`__ library related to a
+    standard deviation of zero have been suppressed where a standard deviation
+    of zero is expected and can not be avoided. One case involves the fixed fit
+    parameters included in :class:`.CurveFitResult`. Since these are fixed
+    parameters, they have no uncertainty. The other case involves the `lmfit
+    <https://lmfit.github.io/lmfit-py/>`__ library's handling of fixed fit
+    parameters and will be addressed by lmfit directly in the future. In some
+    cases, Uncertainties will propagate the error in a variable and produce a
+    non-finite result when the error should be zero since the variable zero
+    error. For example, the operation ``y ** 0.5`` could lead to 0 with ``inf``
+    standard deviation rather than 0 standard deviation when the nominal value
+    and standard deviation of ``y`` are both 0.


### PR DESCRIPTION
As of Uncertainties 3.2.3, `ufloat()` warns when passed a standard
deviation of 0 because that can lead to problems (see the discussion
[here](https://github.com/lmfit/uncertainties/issues/283).  The
recommendation is to use a plain float instead but we want
`ufloat_params` to return all `UFloats` so that `.n` and `.s` always
exist and the user doesn't need to handle type checking on curve data
results, so here we just ignore the warning.

A standard deviation of 0 is usually not a problem. Uncertainties
propagates errors for all of its variables even when they have 0
standard deviation. If the propagation of one variable leads to a `nan`
or `inf` value, the standard deviation will take on that value even
though, since the variable's standard deviation was 0, the error
propagation could have been skipped for that variable.