### PR TITLE
Update intersphinx mapping and other URLs pointing to IQP Classic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,12 +157,12 @@ html_last_updated_fmt = "%Y/%m/%d"
 autoclass_content = "both"
 intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
     "uncertainties": ("https://pythonhosted.org/uncertainties", None),
     "pandas": ("http://pandas.pydata.org/docs/", None),
     "qiskit_aer": ("https://qiskit.github.io/qiskit-aer/", None),
     "qiskit_dynamics": ("https://qiskit-community.github.io/qiskit-dynamics/", None),
-    "qiskit_ibm_runtime": ("https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/", None),
+    "qiskit_ibm_runtime": ("https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/", None),
 }
 
 

--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -20,7 +20,7 @@ Saving
 .. note::
     This guide requires :external+qiskit_ibm_runtime:doc:`qiskit-ibm-runtime <index>` version 0.15 and up, which can be installed with ``python -m pip install qiskit-ibm-runtime``.
     For how to migrate from the older ``qiskit-ibm-provider`` to :external+qiskit_ibm_runtime:doc:`qiskit-ibm-runtime <index>`,
-    consult the `migration guide <https://docs.quantum.ibm.com/api/migration-guides/qiskit-runtime-from-provider>`_.\
+    consult the `migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-runtime-from-ibm-provider>`_.\
 
 You must run the experiment on a real IBM
 backend and not a simulator to be able to save the experiment data. This is done by calling

--- a/docs/howtos/rerun_analysis.rst
+++ b/docs/howtos/rerun_analysis.rst
@@ -14,7 +14,7 @@ Solution
 .. note::
     This guide requires :external+qiskit_ibm_runtime:doc:`qiskit-ibm-runtime <index>` version 0.15 and up, which can be installed with ``python -m pip install qiskit-ibm-runtime``.
     For how to migrate from the older ``qiskit-ibm-provider`` to :external+qiskit_ibm_runtime:doc:`qiskit-ibm-runtime <index>`,
-    consult the `migration guide <https://docs.quantum.ibm.com/api/migration-guides/qiskit-runtime-from-provider>`_.\
+    consult the `migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-runtime-from-ibm-provider>`_.\
 
 Once you recreate the exact experiment you ran and all of its parameters and options,
 you can call the :meth:`.ExperimentData.add_jobs` method with a list of :class:`Job

--- a/docs/howtos/runtime_sessions.rst
+++ b/docs/howtos/runtime_sessions.rst
@@ -19,7 +19,7 @@ In this example, we will pass in a :class:`qiskit_ibm_runtime.SamplerV2` object 
 
 .. note::
     If a sampler object is passed to :meth:`qiskit_experiments.framework.BaseExperiment.run` then the `run options 
-    <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.SamplerExecutionOptionsV2>`_ of the 
+    <https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/options-sampler-execution-options-v2>`_ of the 
     sampler object are used. The execution options set by the experiment are ignored.
 
 .. jupyter-input::

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1150,7 +1150,7 @@ Package Upgrades
   from 0.24 for ``qiskit-terra`` to 0.45 for ``qiskit``. For more information on
   the renaming of Qiskit, see the `Qiskit repository renaming plan
   <https://github.com/Qiskit/RFCs/blob/5793e78dc8e4d8d17f8ef7fad789c6c5ebd3a061/0011-repo-rename.md>`__
-  and the `Qiskit 1.0 migration guide <https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0>`__.
+  and the `Qiskit 1.0 migration guide <https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-1.0>`__.
 
 .. releasenotes/notes/0.6/runtime-provider-support-5358b72ec0035419.yaml @ b'3b039c5df784748597261d38599c1c7cb2074377'
 
@@ -1158,7 +1158,7 @@ Package Upgrades
   ``qiskit-ibm-provider`` is now deprecated and will be removed
   in the next release. Users should migrate to :external+qiskit_ibm_runtime:doc:`qiskit-ibm-runtime <index>` following the
   `runtime migration guide
-  <https://docs.quantum.ibm.com/api/migration-guides/qiskit-runtime-from-provider>`_.
+  <https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-runtime-from-ibm-provider>`_.
   :external+qiskit_ibm_runtime:doc:`qiskit-ibm-runtime <index>` is not listed as a dependency for compatibility reasons, but users
   will need it to run experiments on IBM backends.
 

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -6,7 +6,7 @@ Installation
 ============
 
 Qiskit Experiments is built on top of Qiskit, so we recommend that you first install
-Qiskit following its `installation guide <https://docs.quantum.ibm.com/start/install>`__. Qiskit
+Qiskit following its `installation guide <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__. Qiskit
 Experiments supports the same platforms as Qiskit itself and Python versions 3.9 through 3.13.
 
 Qiskit Experiments releases can be installed via the Python package manager ``pip``

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -2,7 +2,7 @@ Tutorials
 =========
 
 These tutorials assume some familiarity with Qiskit (on the level of 
-`IBM Quantum Documentation's introductory guides <https://docs.quantum.ibm.com>`__) but no knowledge of Qiskit Experiments.
+`IBM Quantum Documentation's introductory guides <https://quantum.cloud.ibm.com/docs>`__) but no knowledge of Qiskit Experiments.
 They're suitable for beginners who want to get started with the package.
 
 .. _basics:

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -383,7 +383,7 @@ class BaseExperiment(ABC, StoreInitArgs):
                 sampler = Sampler(self.backend)
 
                 # have to hand set some of these options
-                # see https://docs.quantum.ibm.com/api/qiskit-ibm-runtime
+                # see https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime
                 # /qiskit_ibm_runtime.options.SamplerExecutionOptionsV2
                 if "init_qubits" in run_options:
                     sampler.options.execution.init_qubits = run_options["init_qubits"]


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.