### PR TITLE
Address deprecated use of Qiskit's QuantumVolume

### DIFF
--- a/qiskit_experiments/library/quantum_volume/qv_experiment.py
+++ b/qiskit_experiments/library/quantum_volume/qv_experiment.py
@@ -14,13 +14,14 @@ Quantum Volume Experiment class.
 """
 
 from typing import Union, Sequence, Optional, List
+import numpy as np
 from numpy.random import Generator, default_rng
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 
 from qiskit.utils.optionals import HAS_AER
 
 from qiskit import QuantumCircuit
-from qiskit.circuit.library import QuantumVolume as QuantumVolumeCircuit
+from qiskit.circuit.library import quantum_volume
 from qiskit import transpile
 from qiskit.providers.backend import Backend
 from qiskit_experiments.framework import BaseExperiment, Options
@@ -193,7 +194,12 @@ class QuantumVolume(BaseExperiment):
 
         # Note: the trials numbering in the metadata is starting from 1 for each new experiment run
         for trial in range(1, self.experiment_options.trials + 1):
-            qv_circ = QuantumVolumeCircuit(depth, depth, seed=rng)
+            # Maximum possible seed to send to quantum_volume()
+            # This is a workound that can be replaced with seed=rng once we
+            # drop support for qiskit<2.2
+            # See https://github.com/Qiskit/qiskit/pull/14586
+            max_value = np.iinfo(np.int64).max
+            qv_circ = quantum_volume(depth, depth, seed=rng.integers(max_value, dtype=np.int64))
             qv_circ.metadata = {
                 "depth": depth,
                 "trial": trial,

--- a/releasenotes/notes/qv-deprecation-6b13e5cb7bc7be3b.yaml
+++ b/releasenotes/notes/qv-deprecation-6b13e5cb7bc7be3b.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    The minimum version of Qiskit was raised from 0.45 to 1.3.
+fixes:
+  - |
+    :class:`~.QuantumVolume` was updated to avoid using the deprecated
+    :class:`qiskit.circuit.library.QuantumVolume` class. The experiment should
+    continue to behave as it has before.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.4
-qiskit>=0.45
+qiskit>=1.3
 qiskit-ibm-experiment>=0.4.6
 qiskit_ibm_runtime>=0.29.0
 matplotlib>=3.4


### PR DESCRIPTION
The `QuantumVolume` class in Qiskit has been deprecated in version 2.2 in favor of the `quantum_volume` function. Here the latter is swapped out for the former. In doing so, a bug with `quantum_volume` was discovered and worked around. `quantum_volume` was added in Qiskit 1.3, so the minimum version of Qiskit was raised from 0.45 to 1.3 since that is a reasonably old version rather than trying to keep using `QuantumVolume` with older versions of Qiskit.