### PR TITLE
Fix `BaseExperiment.from_config` when passed dictionary

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -187,7 +187,7 @@ class BaseExperiment(ABC, StoreInitArgs):
     def from_config(cls, config: Union[ExperimentConfig, Dict]) -> "BaseExperiment":
         """Initialize an experiment from experiment config"""
         if isinstance(config, dict):
-            config = ExperimentConfig(**dict)
+            config = ExperimentConfig(**config)
         ret = cls(*config.args, **config.kwargs)
         if config.experiment_options:
             ret.set_experiment_options(**config.experiment_options)

--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity.py
@@ -573,7 +573,7 @@ class LayerFidelity(BaseExperiment):
     def from_config(cls, config: Union[ExperimentConfig, Dict]) -> "LayerFidelity":
         """Initialize an experiment from experiment config"""
         if isinstance(config, dict):
-            config = ExperimentConfig(**dict)
+            config = ExperimentConfig(**config)
         ret = cls(*config.args, **config.kwargs)
         if config.run_options:
             ret.set_run_options(**config.run_options)

--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity_unitary.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity_unitary.py
@@ -666,7 +666,7 @@ class LayerFidelityUnitary(BaseExperiment):
     def from_config(cls, config: Union[ExperimentConfig, Dict]) -> "LayerFidelity":
         """Initialize an experiment from experiment config"""
         if isinstance(config, dict):
-            config = ExperimentConfig(**dict)
+            config = ExperimentConfig(**config)
         ret = cls(*config.args, **config.kwargs)
         if config.run_options:
             ret.set_run_options(**config.run_options)

--- a/releasenotes/notes/from-config-dict-6629c37d2572cfbc.yaml
+++ b/releasenotes/notes/from-config-dict-6629c37d2572cfbc.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    A bug that prevented passing a ``dict`` to
+    :meth:`.BaseExperiment.from_config` from working has been fixed (`#1577
+    <https://github.com/qiskit-community/qiskit-experiments/issues/1577>`__).


### PR DESCRIPTION
Fixes #1577

Fixed erroneous `**dict` usage
