### PR TITLE
Remove references to hgp

### DIFF
--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -2,9 +2,9 @@ Save and load experiment data with the cloud service
 ====================================================
 
 .. note::
-    This guide is only for those who have access to the cloud service. You can 
-    check whether you do by logging into the IBM Quantum interface 
-    and seeing if you can see the `database <https://quantum.ibm.com/experiments>`__.
+    The cloud service at `database <https://quantum.ibm.com/experiments>` has been 
+    sunset in the move to the new IBM Quantum cloud platform. Saving and loading 
+    to the cloud will not work. We are working on a local saving solution.
 
 Problem
 -------

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -427,36 +427,6 @@ class ExperimentData:
         self._db_data.end_datetime = new_end_datetime
 
     @property
-    def hub(self) -> str:
-        """Return the hub of this experiment data.
-
-        Returns:
-            The hub of this experiment data.
-
-        """
-        return self._db_data.hub
-
-    @property
-    def group(self) -> str:
-        """Return the group of this experiment data.
-
-        Returns:
-            The group of this experiment data.
-
-        """
-        return self._db_data.group
-
-    @property
-    def project(self) -> str:
-        """Return the project of this experiment data.
-
-        Returns:
-            The project of this experiment data.
-
-        """
-        return self._db_data.project
-
-    @property
     def experiment_id(self) -> str:
         """Return experiment ID
 
@@ -598,23 +568,9 @@ class ExperimentData:
         self._db_data.backend = self._backend_data.name
         if self._db_data.backend is None:
             self._db_data.backend = str(new_backend)
-        if hasattr(self._backend, "_instance") and self._backend._instance:
-            self.hgp = self._backend._instance
         if recursive:
             for data in self.child_data():
                 data._set_backend(new_backend)
-
-    @property
-    def hgp(self) -> str:
-        """Returns Hub/Group/Project data as a formatted string"""
-        return f"{self.hub}/{self.group}/{self.project}"
-
-    @hgp.setter
-    def hgp(self, new_hgp: str) -> None:
-        """Sets the Hub/Group/Project data from a formatted string"""
-        if re.match(r"[^/]*/[^/]*/[^/]*$", new_hgp) is None:
-            raise QiskitError("hgp can be only given in a <hub>/<group>/<project> format")
-        self._db_data.hub, self._db_data.group, self._db_data.project = new_hgp.split("/")
 
     def _clear_results(self):
         """Delete all currently stored analysis results and figures"""

--- a/releasenotes/notes/fix_hgp_bug-e131e03f71459029.yaml
+++ b/releasenotes/notes/fix_hgp_bug-e131e03f71459029.yaml
@@ -1,0 +1,7 @@
+---
+
+fixes:
+  - |
+    Removed references to hub, group, project in :class:`.ExperimentData` as
+    these are no longer a part of the qiskit-ibm-runtime syntax in the 
+    new cloud platform. 

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -1198,15 +1198,6 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         ]
         self.assertTrue(exp_data._metadata_too_large())
 
-    def test_hgp_setter(self):
-        """Tests usage of the hgp setter"""
-        exp_data = ExperimentData()
-        exp_data.hgp = "ibm-q-internal/deployed/default"
-        self.assertEqual("ibm-q-internal/deployed/default", exp_data.hgp)
-        self.assertEqual("ibm-q-internal", exp_data.hub)
-        self.assertEqual("deployed", exp_data.group)
-        self.assertEqual("default", exp_data.project)
-
     def test_add_delete_artifact(self):
         """Tests adding an artifact and a list of artifacts. Tests deleting an artifact
         by name, ID, and index and ID. Test the metadata is correctly tracking additions


### PR DESCRIPTION
With the change to the qiskit-ibm-runtime service, the hub/group/project access syntax has been removed. Lingering references to this in experiments caused errors with the release of runtime 0.41.0.