### PR TITLE
Move 0.12 prelude into another note

### DIFF
--- a/releasenotes/notes/add-benchmark-suffix-c3ab8c14c89edb33.yaml
+++ b/releasenotes/notes/add-benchmark-suffix-c3ab8c14c89edb33.yaml
@@ -1,4 +1,9 @@
 ---
+prelude: >
+    Qiskit Experiments 0.12 introduces a new option for labeling results of
+    layer fidelity experiments. Additionally, it addresses an incompatibility
+    with :external+qiskit_ibm_runtime:doc:`qiskit-ibm-runtime <index>` version
+    0.41 that prevents experiments from running.
 features:
   - |
     A new ``benchmark_suffix`` argument for the :class:`~.LayerFidelity`

--- a/releasenotes/notes/release0.12-b3db51c607bbd2f6.yaml
+++ b/releasenotes/notes/release0.12-b3db51c607bbd2f6.yaml
@@ -1,6 +1,0 @@
----
-prelude: >
-    Qiskit Experiments 0.12 introduces a new option for labeling results of
-    layer fidelity experiments. Additionally, it addresses an incompatibility
-    with :external+qiskit_ibm_runtime:doc:`qiskit-ibm-runtime <index>` version
-    0.41 that prevents experiments from running.


### PR DESCRIPTION
The commit with the 0.12.0 release notes prelude did not make it into the 0.12.0 tag so reno will treat it as being part of 0.12.1 or 0.13.0. Here we delete the prelude's note and move its content back into an earlier note file that did make the 0.12.0 release.