### PR TITLE
Work around lmfit limiting RBAnalysis to 10,000 Cliffords

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -50,6 +50,14 @@ class RBAnalysis(curve.CurveAnalysis):
 
             F(x) = a \alpha^x + b
 
+        .. note::
+
+            The string expression model used by the class is implemented using
+            :math:`(\alpha^{(x / 10)})^{10}` in order to allow :math:`x` to vary up
+            to 100,000 without hitting an exponentiation limit of 10,000
+            imposed by the `LMFIT
+            <https://lmfit.github.io/lmfit-py/intro.html>`__ fitting framework.
+
     # section: fit_parameters
         defpar a:
             desc: Height of decay curve.
@@ -73,7 +81,14 @@ class RBAnalysis(curve.CurveAnalysis):
         super().__init__(
             models=[
                 lmfit.models.ExpressionModel(
-                    expr="a * alpha ** x + b",
+                    # NOTE: the `/10` and then `** 10` are done because asteval
+                    # (used by lmfit to evaluate the model expression) limits
+                    # exponents to 10,000 as a security precaution. For gates
+                    # with errors around 1e-4, it is desirable to go beyond
+                    # 10,000 Cliffords. By splitting out the factors of 10 like
+                    # this, we can have `x` go up to 100,000 Cliffords without
+                    # hitting the asteval limit.
+                    expr="a * (alpha ** (x/10)) ** 10 + b",
                     name="rb_decay",
                 )
             ]

--- a/releasenotes/notes/rb-clifford-10k-3429e74f4a82848e.yaml
+++ b/releasenotes/notes/rb-clifford-10k-3429e74f4a82848e.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    A workaround was added for a limit on exponentiation imposed by `LMFIT
+    <https://lmfit.github.io/lmfit-py/intro.html>`__ which prevented
+    :class:`.RBAnalysis` from working on experiments with Clifford lengths
+    longer than 10,000. See `#1594
+    <https://github.com/qiskit-community/qiskit-experiments/issues/1594>`__.


### PR DESCRIPTION
lmfit (through its asteval dependnecy) limits exponentiation in its expression models to 10,000. The limit is there to avoid denial of service attacks where user input could be substituted into a model and Python integers which are unbounded and could take up exponential amounts of memory. In qiskit-experiments, this case is not a concern. The workaround implemented here is to divide the exponential in the curve by 10 and then exponentiate the result by 10. This change allows up to 100,000 Cliffords which should be enough. The alternative workaround is to change `asteval.astutils.MAX_EXPONENT` to a sufficiently large value.

Closes https://github.com/qiskit-community/qiskit-experiments/issues/1594