### PR TITLE
Remove debugging line from RB analysis test

### DIFF
--- a/test/library/randomized_benchmarking/test_rb_analysis.py
+++ b/test/library/randomized_benchmarking/test_rb_analysis.py
@@ -197,7 +197,6 @@ class TestEPGAnalysis(QiskitExperimentsTestCase):
             ),
         )
         result_2qrb = analysis_2qrb.run(self.expdata_2qrb)
-        analysis_2qrb._run_analysis(self.expdata_2qrb)
         self.assertExperimentDone(result_2qrb)
         cx_epg_corrected = result_2qrb.analysis_results("EPG_cx", dataframe=True).iloc[0]
         self.assertLess(


### PR DESCRIPTION
The tests in `test_rb_analysis.py` call `analysis.run()` which runs the analysis in a background thread. For debugging purposes a call to `analysis._run_analysis()` was added to one test which runs the analysis in the main thread where it could be accesssed more easily from a debugger.

Running the analysis twice is mostly harmless. However, it uncovered a thread safety issue with Uncertainties. To improve perfomance, Uncertainties stores error propagation coefficients as series of nested values that can be multiplied and summed when the final error values are needed and replaces its internal representation with the expanded form on first calculation. The way Uncertainties modifies these coefficients is not threadsafe. It iterates and modifies as it processes the coefficients. The test that starts the background thread exposed this lack of thread safety. Occasionally the test fails with this error:

```
      File "/home/runner/work/qiskit-experiments/qiskit-experiments/qiskit_experiments/curve_analysis/utils.py", line 100, in analysis_result_to_repr
    if result.value.std_dev is not None and np.isfinite(result.value.std_dev):
       ^^^^^^^^^^^^^^^^^^^^

      File "/home/runner/work/qiskit-experiments/qiskit-experiments/.tox/qiskit-main/lib/python3.14/site-packages/uncertainties/core.py", line 511, in std_dev
    return float(sqrt(sum(delta**2 for delta in self.error_components().values())))
                                                ~~~~~~~~~~~~~~~~~~~~~^^

      File "/home/runner/work/qiskit-experiments/qiskit-experiments/.tox/qiskit-main/lib/python3.14/site-packages/uncertainties/core.py", line 476, in error_components
    for variable, derivative in self.derivatives.items():
                                ^^^^^^^^^^^^^^^^

      File "/home/runner/work/qiskit-experiments/qiskit-experiments/.tox/qiskit-main/lib/python3.14/site-packages/uncertainties/core.py", line 450, in derivatives
    self._linear_part.expand()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^

      File "/home/runner/work/qiskit-experiments/qiskit-experiments/.tox/qiskit-main/lib/python3.14/site-packages/uncertainties/core.py", line 311, in expand
    (main_factor, main_expr) = self.linear_combo.pop()
                               ~~~~~~~~~~~~~~~~~~~~~^^

    TypeError: pop expected at least 1 argument, got 0
```

The failure is due to both the main thread and background thread analysis runs hitting `std_dev` at the same time and one of the threads replacing the internal representation of the coefficients while the other is still processing it (the replacement replaces a list with a dict; for the list `.pop()` is the correct syntax but once it becomes a dict `.pop()` needs to be passed a dict key).

Here the extra analysis run is removed but the Uncertainties thread safety issue should be kept in mind going forward.