### PR TITLE
Add peak separability diagnostics to curve_analysis

### DIFF
--- a/qiskit_experiments/curve_analysis/__init__.py
+++ b/qiskit_experiments/curve_analysis/__init__.py
@@ -86,6 +86,16 @@ Initial Guess Estimators
     guess.min_height
     guess.oscillation_exp_decay
 
+Separability Diagnostics
+========================
+
+.. autosummary::
+    :toctree: ../stubs/
+
+    separability.peak_separability
+    separability.SeparabilityReport
+
+
 Utilities
 =========
 .. autosummary::
@@ -112,6 +122,7 @@ from .curve_data import (
     ParameterRepr,
 )
 from . import guess
+from . import separability
 from . import fit_function
 from . import utils
 

--- a/qiskit_experiments/curve_analysis/separability.py
+++ b/qiskit_experiments/curve_analysis/separability.py
@@ -1,0 +1,95 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Separability diagnostics for fits with nearly overlapping spectral features."""
+
+from __future__ import annotations
+
+import dataclasses
+
+TASK_EXPONENTS = {
+    "amplitudes_fixed_frequencies": 1,
+    "frequencies": 2,
+    "amplitudes_free_frequencies": 3,
+}
+"""Error amplification exponents for the three estimation tasks.
+
+When two spectral features (resonance peaks, oscillation tones) sit a
+distance ``separation`` apart and each has scale ``linewidth``, the
+standard error of a fit grows like ``(linewidth / separation) ** p``
+once the features overlap, with an exponent ``p`` that depends on what
+is estimated: amplitudes with the two frequencies held fixed (p = 1),
+the frequencies themselves (p = 2), or amplitudes with the frequencies
+also free (p = 3). The exponents were measured across avoided crossings
+on numerical relativity waveforms and quantum hardware, see
+https://github.com/maiconburn/recoverability-criticality
+(DOI 10.5281/zenodo.22156019); the frequency case matches the Fisher
+scaling of arXiv:2605.16199 and the free-frequency amplitude case the
+classical Prony super-resolution scaling.
+"""
+
+
+@dataclasses.dataclass(frozen=True)
+class SeparabilityReport:
+    """Result of :func:`peak_separability`.
+
+    Attributes:
+        ratio: ``separation / linewidth``.
+        regime: ``"resolved"`` when the ratio is at least 2,
+            ``"marginal"`` when it is between 0.5 and 2, and
+            ``"unresolved"`` below 0.5. The thresholds are rules of
+            thumb, not sharp boundaries.
+        amplification: Expected error amplification for each task in
+            :data:`TASK_EXPONENTS`, equal to ``max(1, 1 / ratio) ** p``.
+    """
+
+    ratio: float
+    regime: str
+    amplification: dict[str, float]
+
+
+def peak_separability(separation: float, linewidth: float) -> SeparabilityReport:
+    """Assess how well two nearby spectral features can be separated.
+
+    Use this before or after fitting a two-peak or two-tone model to
+    judge which fit outputs deserve trust. The amplification factors are
+    asymptotic guides, valid up to prefactors of order one, so compare
+    them between configurations rather than reading them as exact.
+
+    Args:
+        separation: Distance between the two feature positions, in the
+            same units as ``linewidth`` (for example Hz).
+        linewidth: Characteristic width of a single feature, for
+            example the full width at half maximum.
+
+    Returns:
+        A :class:`SeparabilityReport` with the ratio, a qualitative
+        regime label, and per-task error amplification factors.
+
+    Raises:
+        ValueError: If ``separation`` or ``linewidth`` is not positive.
+    """
+    if separation <= 0 or linewidth <= 0:
+        raise ValueError("separation and linewidth must be positive.")
+
+    ratio = separation / linewidth
+    if ratio >= 2:
+        regime = "resolved"
+    elif ratio >= 0.5:
+        regime = "marginal"
+    else:
+        regime = "unresolved"
+
+    base = max(1.0, 1.0 / ratio)
+    amplification = {task: base**p for task, p in TASK_EXPONENTS.items()}
+
+    return SeparabilityReport(ratio=ratio, regime=regime, amplification=amplification)

--- a/releasenotes/notes/add-peak-separability-diagnostics-3f1a2b4c5d6e7f80.yaml
+++ b/releasenotes/notes/add-peak-separability-diagnostics-3f1a2b4c5d6e7f80.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Added :func:`~qiskit_experiments.curve_analysis.separability.peak_separability`,
+    a diagnostic for fits with two nearly overlapping spectral features,
+    such as resonance doublets near qubit and two-level-system anticrossings.
+    Given the feature separation and linewidth it reports a qualitative
+    regime and the expected error amplification for three estimation
+    tasks: amplitudes with fixed frequencies (inverse ratio to the first
+    power), the frequencies themselves (second power), and amplitudes
+    with free frequencies (third power).

--- a/test/curve_analysis/test_separability.py
+++ b/test/curve_analysis/test_separability.py
@@ -1,0 +1,54 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test separability diagnostics."""
+
+from test.base import QiskitExperimentsTestCase
+
+from qiskit_experiments.curve_analysis.separability import (
+    TASK_EXPONENTS,
+    peak_separability,
+)
+
+
+class TestPeakSeparability(QiskitExperimentsTestCase):
+    """Test peak_separability."""
+
+    def test_regimes(self):
+        """Regime labels follow the documented thresholds."""
+        self.assertEqual(peak_separability(10, 1).regime, "resolved")
+        self.assertEqual(peak_separability(1, 1).regime, "marginal")
+        self.assertEqual(peak_separability(0.1, 1).regime, "unresolved")
+
+    def test_no_amplification_when_resolved(self):
+        """Well separated features have amplification one for all tasks."""
+        report = peak_separability(10, 1)
+        for value in report.amplification.values():
+            self.assertEqual(value, 1.0)
+
+    def test_hierarchy(self):
+        """Overlapping features amplify with exponents 1, 2 and 3."""
+        report = peak_separability(0.1, 1)
+        amp = report.amplification
+        self.assertAlmostEqual(amp["amplitudes_fixed_frequencies"], 10.0)
+        self.assertAlmostEqual(amp["frequencies"], 100.0)
+        self.assertAlmostEqual(amp["amplitudes_free_frequencies"], 1000.0)
+        self.assertEqual(
+            set(amp), set(TASK_EXPONENTS)
+        )
+
+    def test_invalid_inputs(self):
+        """Non positive inputs raise."""
+        with self.assertRaises(ValueError):
+            peak_separability(0, 1)
+        with self.assertRaises(ValueError):
+            peak_separability(1, -1)


### PR DESCRIPTION
## Summary

Adds `qiskit_experiments.curve_analysis.separability.peak_separability`, a small diagnostic for fits with two nearly overlapping spectral features, for example a resonance doublet near a qubit and two-level-system anticrossing, or two close tones in a Ramsey record.

Given the separation between the two features and their linewidth, it returns a qualitative regime (resolved, marginal, unresolved) and the expected error amplification for three different estimation tasks:

| task | amplification |
|---|---|
| amplitudes, frequencies fixed | (linewidth / separation) |
| frequencies themselves | (linewidth / separation)^2 |
| amplitudes, frequencies free | (linewidth / separation)^3 |

## Why

When two features overlap, a fit does not fail loudly. It returns numbers with optimistic error bars, and how wrong those are depends strongly on what is being estimated. A typical qubit-TLS example: with 0.5 MHz linewidths, peaks 5 MHz apart are clean, but at 0.2 MHz separation the frequency errors inflate by about 6 times and free amplitude errors by about 16 times. The diagnostic makes this visible in one call, before or after the fit.

The exponents were measured across avoided crossings on numerical relativity waveforms and on IBM quantum hardware, see https://github.com/maiconburn/recoverability-criticality (DOI 10.5281/zenodo.22156019). The frequency case matches the Fisher scaling of arXiv:2605.16199 and the free amplitude case matches the classical Prony super-resolution scaling. The factors are asymptotic guides, valid up to prefactors of order one, and the docstrings say so.

## Details and comments

- New module plus tests, one autosummary section in the `curve_analysis` docs, and a release note. No existing behavior is changed.
- `test/curve_analysis/` passes locally (121 tests).
