### PR TITLE
Loosen cvxpy solver tolerance in failing tests

### DIFF
--- a/test/library/tomography/test_state_tomography.py
+++ b/test/library/tomography/test_state_tomography.py
@@ -493,6 +493,9 @@ class TestStateTomography(QiskitExperimentsTestCase):
             with self.subTest(fitter=fitter):
                 if fitter:
                     exp.analysis.set_options(fitter=fitter)
+                    if "cvxpy" in fitter:
+                        # Increaes from default tolerance of 1e-5 to avoid cvxpy warnings.
+                        exp.analysis.set_options(fitter_options={"eps_abs": 3e-4})
                 fitdata = exp.analysis.run(expdata)
                 states = fitdata.analysis_results("state", dataframe=True)
                 self.assertEqual(len(states), 2 ** len(circuit_clbits))

--- a/tox.ini
+++ b/tox.ini
@@ -154,6 +154,7 @@ commands =
 [testenv:docs-clean]
 skip_install = true
 deps =
+dependency_groups =
 commands = python -c "import shutil; shutil.rmtree('{toxinidir}/docs/stubs/', ignore_errors=True); shutil.rmtree('{toxinidir}/docs/_build', ignore_errors=True)"
 
 [testenv:relnotes]


### PR DESCRIPTION
With the new release of scs, some of the tomography tests started failing because they warned about reaching max iterations of the solver and we fail tests that generate warnings. The partial solutions still satisfy the tests that are done on the results of the solver, so here the tolerance of the solver is just bumped up to avoid warnings. Maybe there is something singular about how the test is set up to measure just qubits in the ground state.